### PR TITLE
Add cloneable http3 client channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio-util = "0.7"
 tonic = { version = "0.14", default-features = false, features = ["router", "codegen", "transport"] }
 tonic-prost-build = "0.14"
 tonic-prost = "0.14"
-tower = { version = "0.5", default-features = false, features = ["util"] }
+tower = { version = "0.5", default-features = false, features = ["buffer", "util"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = [
   "fmt",

--- a/h3-util/src/client.rs
+++ b/h3-util/src/client.rs
@@ -19,10 +19,7 @@ use tower::{
 };
 
 use crate::client_conn;
-use crate::{
-    client_body::H3IncomingClient,
-    executor::SharedExec,
-};
+use crate::{client_body::H3IncomingClient, executor::SharedExec};
 
 const DEFAULT_BUFFER_SIZE: usize = 1024;
 
@@ -70,6 +67,7 @@ where
     B::Data: Send,
     B::Error: Into<crate::Error> + Send,
 {
+    #[allow(clippy::type_complexity)]
     svc: Buffer<
         Request<B>,
         BoxFuture<'static, Result<Response<H3IncomingClient<C::RS, Bytes>>, crate::Error>>,
@@ -94,6 +92,7 @@ pub struct ResponseFuture<C>
 where
     C: H3Connector,
 {
+    #[allow(clippy::type_complexity)]
     inner: BufferResponseFuture<
         BoxFuture<'static, Result<Response<H3IncomingClient<C::RS, Bytes>>, crate::Error>>,
     >,
@@ -106,8 +105,9 @@ where
     B::Data: Send,
     B::Error: Into<crate::Error> + Send,
 {
-    pub fn new(connector: C, uri: Uri, executor: SharedExec) -> Self {
-        let svc = H3Connection::new(connector, uri, executor.clone());
+    pub fn new(connector: C, uri: Uri, executor: Option<SharedExec>) -> Self {
+        let executor = executor.unwrap_or_else(SharedExec::tokio);
+        let svc = H3Connection::new(connector, uri, Some(executor.clone()));
         let (svc, worker) = Buffer::pair(svc, DEFAULT_BUFFER_SIZE);
         executor.execute(worker);
         Self { svc }
@@ -156,7 +156,7 @@ where
     B::Error: Into<crate::Error> + Send,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Channel").finish()
+        f.debug_struct("H3Channel").finish()
     }
 }
 
@@ -191,7 +191,8 @@ where
     B::Data: Send,
     B::Error: Into<crate::Error> + Send,
 {
-    pub fn new(connector: C, uri: Uri, executor: SharedExec) -> Self {
+    pub fn new(connector: C, uri: Uri, executor: Option<SharedExec>) -> Self {
+        let executor = executor.unwrap_or_else(SharedExec::tokio);
         let sender = client_conn::RequestSender::new(connector, uri, executor);
         Self {
             inner: BoxService::new(sender),

--- a/h3-util/src/client.rs
+++ b/h3-util/src/client.rs
@@ -1,11 +1,30 @@
-use std::net::SocketAddr;
+use std::{
+    fmt,
+    future::Future,
+    net::SocketAddr,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use futures::future::BoxFuture;
-use hyper::body::{Body, Bytes};
-use hyper::{Request, Response, Uri};
+use hyper::{
+    Request, Response, Uri,
+    body::{Body, Bytes},
+    rt::Executor,
+};
+use tower::{
+    Service,
+    buffer::{Buffer, future::ResponseFuture as BufferResponseFuture},
+    util::BoxService,
+};
 
-use crate::client_body::H3IncomingClient;
 use crate::client_conn;
+use crate::{
+    client_body::H3IncomingClient,
+    executor::SharedExec,
+};
+
+const DEFAULT_BUFFER_SIZE: usize = 1024;
 
 pub trait H3Connector: Send + 'static + Clone {
     type CONN: h3::quic::Connection<
@@ -43,6 +62,113 @@ pub async fn dns_resolve(uri: &Uri) -> std::io::Result<Vec<SocketAddr>> {
     }
 }
 
+/// Cloneable http3 client channel, which can be used to enable multiplexing requests.
+pub struct H3Channel<C, B>
+where
+    C: H3Connector,
+    B: Body + Send + 'static + Unpin,
+    B::Data: Send,
+    B::Error: Into<crate::Error> + Send,
+{
+    svc: Buffer<
+        Request<B>,
+        BoxFuture<'static, Result<Response<H3IncomingClient<C::RS, Bytes>>, crate::Error>>,
+    >,
+}
+
+impl<C, B> Clone for H3Channel<C, B>
+where
+    C: H3Connector,
+    B: Body + Send + 'static + Unpin,
+    B::Data: Send,
+    B::Error: Into<crate::Error> + Send,
+{
+    fn clone(&self) -> Self {
+        Self {
+            svc: self.svc.clone(),
+        }
+    }
+}
+
+pub struct ResponseFuture<C>
+where
+    C: H3Connector,
+{
+    inner: BufferResponseFuture<
+        BoxFuture<'static, Result<Response<H3IncomingClient<C::RS, Bytes>>, crate::Error>>,
+    >,
+}
+
+impl<C, B> H3Channel<C, B>
+where
+    C: H3Connector,
+    B: Body + Send + 'static + Unpin,
+    B::Data: Send,
+    B::Error: Into<crate::Error> + Send,
+{
+    pub fn new(connector: C, uri: Uri, executor: SharedExec) -> Self {
+        let svc = H3Connection::new(connector, uri, executor.clone());
+        let (svc, worker) = Buffer::pair(svc, DEFAULT_BUFFER_SIZE);
+        executor.execute(worker);
+        Self { svc }
+    }
+}
+
+impl<C, B> Service<Request<B>> for H3Channel<C, B>
+where
+    C: H3Connector,
+    B: Body + Send + 'static + Unpin,
+    B::Data: Send,
+    B::Error: Into<crate::Error> + Send,
+{
+    type Response = Response<H3IncomingClient<C::RS, Bytes>>;
+    type Error = crate::Error;
+    type Future = ResponseFuture<C>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Service::poll_ready(&mut self.svc, cx).map_err(crate::Error::from)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let inner = Service::call(&mut self.svc, req);
+        ResponseFuture { inner }
+    }
+}
+
+impl<C> Future for ResponseFuture<C>
+where
+    C: H3Connector,
+{
+    type Output = Result<Response<H3IncomingClient<C::RS, Bytes>>, crate::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.inner)
+            .poll(cx)
+            .map_err(crate::Error::from)
+    }
+}
+
+impl<C, B> fmt::Debug for H3Channel<C, B>
+where
+    C: H3Connector,
+    B: Body + Send + 'static + Unpin,
+    B::Data: Send,
+    B::Error: Into<crate::Error> + Send,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Channel").finish()
+    }
+}
+
+impl<C> fmt::Debug for ResponseFuture<C>
+where
+    C: H3Connector,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResponseFuture").finish()
+    }
+}
+
 /// h3 client connection, wrapping inner types for ease of use.
 /// All request will be sent to the connection established using the connector.
 /// Currently connector can only connect to a fixed server (to support grpc use case).
@@ -55,8 +181,7 @@ where
     B::Error: Into<crate::Error>,
 {
     #[allow(clippy::type_complexity)]
-    inner:
-        tower::util::BoxService<Request<B>, Response<H3IncomingClient<C::RS, Bytes>>, crate::Error>,
+    inner: BoxService<Request<B>, Response<H3IncomingClient<C::RS, Bytes>>, crate::Error>,
 }
 
 impl<C, B> H3Connection<C, B>
@@ -66,15 +191,15 @@ where
     B::Data: Send,
     B::Error: Into<crate::Error> + Send,
 {
-    pub fn new(connector: C, uri: Uri) -> Self {
-        let sender = client_conn::RequestSender::new(connector, uri);
+    pub fn new(connector: C, uri: Uri, executor: SharedExec) -> Self {
+        let sender = client_conn::RequestSender::new(connector, uri, executor);
         Self {
-            inner: tower::util::BoxService::new(sender),
+            inner: BoxService::new(sender),
         }
     }
 }
 
-impl<C, B> tower::Service<Request<B>> for H3Connection<C, B>
+impl<C, B> Service<Request<B>> for H3Connection<C, B>
 where
     C: H3Connector,
     B: Body + Send + 'static + Unpin,
@@ -85,11 +210,8 @@ where
     type Error = crate::Error;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-    fn poll_ready(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        tower::Service::poll_ready(&mut self.inner, cx)
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Service::poll_ready(&mut self.inner, cx)
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
@@ -126,7 +248,6 @@ where
         &mut self,
         req: Request<B>,
     ) -> Result<Response<H3IncomingClient<C::RS, Bytes>>, crate::Error> {
-        use tower::Service;
         // wait for ready
         futures::future::poll_fn(|cx| self.channel.poll_ready(cx)).await?;
         self.channel.call(req).await

--- a/h3-util/src/client_conn.rs
+++ b/h3-util/src/client_conn.rs
@@ -100,14 +100,14 @@ impl<CONN> RequestSender<CONN>
 where
     CONN: H3Connector,
 {
-    pub fn new(conn: CONN, uri: Uri) -> Self {
+    pub fn new(conn: CONN, uri: Uri, executor: SharedExec) -> Self {
         Self {
             conn,
             send_request: None,
             driver_rx: None,
             make_send_request_fut: None,
             uri,
-            executor: SharedExec::tokio(), // TODO: expose the executor for user.
+            executor,
         }
     }
 }

--- a/tonic-h3-tests/examples/client.rs
+++ b/tonic-h3-tests/examples/client.rs
@@ -13,7 +13,7 @@ async fn main() {
         "localhost".to_string(),
         client_endpoint.clone(),
     );
-    let channel = tonic_h3::H3Channel::new(cc, uri.clone());
+    let channel = tonic_h3::H3Channel::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
 
     tracing::debug!("making greeter client.");
     let mut client = tonic_h3_test::greeter_client::GreeterClient::new(channel);

--- a/tonic-h3-tests/examples/client.rs
+++ b/tonic-h3-tests/examples/client.rs
@@ -13,7 +13,7 @@ async fn main() {
         "localhost".to_string(),
         client_endpoint.clone(),
     );
-    let channel = tonic_h3::H3Channel::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
+    let channel = tonic_h3::H3Channel::new(cc, uri.clone(), None);
 
     tracing::debug!("making greeter client.");
     let mut client = tonic_h3_test::greeter_client::GreeterClient::new(channel);

--- a/tonic-h3-tests/examples/mp-client.rs
+++ b/tonic-h3-tests/examples/mp-client.rs
@@ -1,0 +1,41 @@
+use http::Uri;
+use tokio::task::JoinSet;
+
+#[tokio::main]
+async fn main() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .try_init();
+    let client_endpoint = tonic_h3_test::make_test_quinn_client_endpoint();
+
+    let uri: Uri = "https://127.0.0.1:5047".parse().unwrap();
+    let cc = h3_util::quinn::H3QuinnConnector::new(
+        uri.clone(),
+        "localhost".to_string(),
+        client_endpoint.clone(),
+    );
+    let channel =
+        h3_util::client::H3Channel::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
+
+    tracing::debug!("making greeter client.");
+    let mut join_set = JoinSet::new();
+    for _ in 0..2 {
+        {
+            let channel = channel.clone();
+            join_set.spawn(async move {
+                let mut client = tonic_h3_test::greeter_client::GreeterClient::new(channel);
+
+                tracing::debug!("sending request.");
+                {
+                    let request = tonic::Request::new(tonic_h3_test::HelloRequest {
+                        name: "Tonic".into(),
+                    });
+                    let response = client.say_hello(request).await.unwrap();
+
+                    tracing::debug!("RESPONSE={:?}", response);
+                }
+            });
+        }
+    }
+    join_set.join_all().await;
+}

--- a/tonic-h3-tests/examples/mp-client.rs
+++ b/tonic-h3-tests/examples/mp-client.rs
@@ -14,8 +14,7 @@ async fn main() {
         "localhost".to_string(),
         client_endpoint.clone(),
     );
-    let channel =
-        h3_util::client::H3Channel::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
+    let channel = h3_util::client::H3Channel::new(cc, uri.clone(), None);
 
     tracing::debug!("making greeter client.");
     let mut join_set = JoinSet::new();

--- a/tonic-h3-tests/src/axum.rs
+++ b/tonic-h3-tests/src/axum.rs
@@ -43,11 +43,7 @@ async fn axum_test() {
             "localhost".to_string(),
             client_endpoint.clone(),
         );
-        let channel = h3_util::client::H3Connection::new(
-            cc,
-            uri.clone(),
-            h3_util::executor::SharedExec::tokio(),
-        );
+        let channel = h3_util::client::H3Connection::new(cc, uri.clone(), None);
         let mut client = h3_util::client::H3Client::new(channel);
         let req = Request::builder()
             .method("GET")
@@ -93,7 +89,7 @@ async fn test_client(uri: Uri) {
             uri.host().unwrap().to_string(),
             client_endpoint.clone(),
         );
-        let channel = h3_util::client::H3Connection::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
+        let channel = h3_util::client::H3Connection::new(cc, uri.clone(), None);
         let mut client = h3_util::client::H3Client::new(channel);
         let req = Request::builder()
             .method("GET")

--- a/tonic-h3-tests/src/axum.rs
+++ b/tonic-h3-tests/src/axum.rs
@@ -43,7 +43,11 @@ async fn axum_test() {
             "localhost".to_string(),
             client_endpoint.clone(),
         );
-        let channel = h3_util::client::H3Connection::new(cc, uri.clone());
+        let channel = h3_util::client::H3Connection::new(
+            cc,
+            uri.clone(),
+            h3_util::executor::SharedExec::tokio(),
+        );
         let mut client = h3_util::client::H3Client::new(channel);
         let req = Request::builder()
             .method("GET")
@@ -89,7 +93,7 @@ async fn test_client(uri: Uri) {
             uri.host().unwrap().to_string(),
             client_endpoint.clone(),
         );
-        let channel = h3_util::client::H3Connection::new(cc, uri.clone());
+        let channel = h3_util::client::H3Connection::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
         let mut client = h3_util::client::H3Client::new(channel);
         let req = Request::builder()
             .method("GET")

--- a/tonic-h3-tests/src/cert_error.rs
+++ b/tonic-h3-tests/src/cert_error.rs
@@ -28,7 +28,7 @@ async fn quinn_cert_error_no_panic() {
         "localhost".to_string(),
         strict_client_endpoint.clone(),
     );
-    let channel = tonic_h3::H3Channel::new(cc, uri, h3_util::executor::SharedExec::tokio());
+    let channel = tonic_h3::H3Channel::new(cc, uri, None);
     let mut client = crate::greeter_client::GreeterClient::new(channel);
 
     // First call should fail with a TLS error, not a panic.

--- a/tonic-h3-tests/src/cert_error.rs
+++ b/tonic-h3-tests/src/cert_error.rs
@@ -28,7 +28,7 @@ async fn quinn_cert_error_no_panic() {
         "localhost".to_string(),
         strict_client_endpoint.clone(),
     );
-    let channel = tonic_h3::H3Channel::new(cc, uri);
+    let channel = tonic_h3::H3Channel::new(cc, uri, h3_util::executor::SharedExec::tokio());
     let mut client = crate::greeter_client::GreeterClient::new(channel);
 
     // First call should fail with a TLS error, not a panic.

--- a/tonic-h3-tests/src/lib.rs
+++ b/tonic-h3-tests/src/lib.rs
@@ -622,7 +622,8 @@ mod doc_example {
             "localhost".to_string(),
             client_endpoint.clone(),
         );
-        let channel = tonic_h3::H3Channel::new(cc, uri.clone());
+        let channel =
+            tonic_h3::H3Channel::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
         let mut client = crate::greeter_client::GreeterClient::new(channel);
         let request = tonic::Request::new(crate::HelloRequest {
             name: "Tonic".into(),

--- a/tonic-h3-tests/src/lib.rs
+++ b/tonic-h3-tests/src/lib.rs
@@ -622,8 +622,7 @@ mod doc_example {
             "localhost".to_string(),
             client_endpoint.clone(),
         );
-        let channel =
-            tonic_h3::H3Channel::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
+        let channel = tonic_h3::H3Channel::new(cc, uri.clone(), None);
         let mut client = crate::greeter_client::GreeterClient::new(channel);
         let request = tonic::Request::new(crate::HelloRequest {
             name: "Tonic".into(),

--- a/tonic-h3-tests/src/mix.rs
+++ b/tonic-h3-tests/src/mix.rs
@@ -47,8 +47,7 @@ async fn h3_test(
             "localhost".to_string(),
             client_endpoint.clone(),
         );
-        let channel =
-            tonic_h3::H3Channel::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
+        let channel = tonic_h3::H3Channel::new(cc, uri.clone(), None);
         let mut client = crate::greeter_client::GreeterClient::new(channel);
 
         {
@@ -126,8 +125,7 @@ async fn h3_test(
             "localhost".to_string(),
             s2n_ep.clone(),
         );
-        let channel =
-            tonic_h3::H3Channel::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
+        let channel = tonic_h3::H3Channel::new(cc, uri.clone(), None);
         let mut client = crate::greeter_client::GreeterClient::new(channel);
         {
             let request = tonic::Request::new(crate::HelloRequest {
@@ -152,7 +150,7 @@ async fn h3_test(
                 msquic_waiter.clone(),
             ),
             uri.clone(),
-            h3_util::executor::SharedExec::tokio(),
+            None,
         );
         let mut client = crate::greeter_client::GreeterClient::new(channel);
         {

--- a/tonic-h3-tests/src/mix.rs
+++ b/tonic-h3-tests/src/mix.rs
@@ -47,7 +47,8 @@ async fn h3_test(
             "localhost".to_string(),
             client_endpoint.clone(),
         );
-        let channel = tonic_h3::H3Channel::new(cc, uri.clone());
+        let channel =
+            tonic_h3::H3Channel::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
         let mut client = crate::greeter_client::GreeterClient::new(channel);
 
         {
@@ -125,7 +126,8 @@ async fn h3_test(
             "localhost".to_string(),
             s2n_ep.clone(),
         );
-        let channel = tonic_h3::H3Channel::new(cc, uri.clone());
+        let channel =
+            tonic_h3::H3Channel::new(cc, uri.clone(), h3_util::executor::SharedExec::tokio());
         let mut client = crate::greeter_client::GreeterClient::new(channel);
         {
             let request = tonic::Request::new(crate::HelloRequest {
@@ -150,6 +152,7 @@ async fn h3_test(
                 msquic_waiter.clone(),
             ),
             uri.clone(),
+            h3_util::executor::SharedExec::tokio(),
         );
         let mut client = crate::greeter_client::GreeterClient::new(channel);
         {

--- a/tonic-h3-tests/src/quiche/mod.rs
+++ b/tonic-h3-tests/src/quiche/mod.rs
@@ -64,11 +64,7 @@ mod quinn_client {
                 "localhost".to_string(),
                 client_endpoint.clone(),
             );
-            let channel = h3_util::client::H3Connection::new(
-                cc,
-                uri.clone(),
-                h3_util::executor::SharedExec::tokio(),
-            );
+            let channel = h3_util::client::H3Connection::new(cc, uri.clone(), None);
             let mut client = h3_util::client::H3Client::new(channel);
             let req = Request::builder()
                 .method("GET")

--- a/tonic-h3-tests/src/quiche/mod.rs
+++ b/tonic-h3-tests/src/quiche/mod.rs
@@ -64,7 +64,11 @@ mod quinn_client {
                 "localhost".to_string(),
                 client_endpoint.clone(),
             );
-            let channel = h3_util::client::H3Connection::new(cc, uri.clone());
+            let channel = h3_util::client::H3Connection::new(
+                cc,
+                uri.clone(),
+                h3_util::executor::SharedExec::tokio(),
+            );
             let mut client = h3_util::client::H3Client::new(channel);
             let req = Request::builder()
                 .method("GET")

--- a/tonic-h3-tests/src/reconnect.rs
+++ b/tonic-h3-tests/src/reconnect.rs
@@ -48,7 +48,7 @@ async fn reconnect_test<T: H3Connector>(
 
     let client_token = CancellationToken::new();
     let (h_cli, cc) = run_client(uri.clone(), client_token.clone());
-    let channel = tonic_h3::H3Channel::new(cc, uri, h3_util::executor::SharedExec::tokio());
+    let channel = tonic_h3::H3Channel::new(cc, uri, None);
     // Client drop is required to end connection. drive will end after connection end.
     // Or client endpoint needs to be closed.
     let mut client = crate::greeter_client::GreeterClient::new(channel);

--- a/tonic-h3-tests/src/reconnect.rs
+++ b/tonic-h3-tests/src/reconnect.rs
@@ -48,7 +48,7 @@ async fn reconnect_test<T: H3Connector>(
 
     let client_token = CancellationToken::new();
     let (h_cli, cc) = run_client(uri.clone(), client_token.clone());
-    let channel = tonic_h3::H3Channel::new(cc, uri);
+    let channel = tonic_h3::H3Channel::new(cc, uri, h3_util::executor::SharedExec::tokio());
     // Client drop is required to end connection. drive will end after connection end.
     // Or client endpoint needs to be closed.
     let mut client = crate::greeter_client::GreeterClient::new(channel);

--- a/tonic-h3/src/client.rs
+++ b/tonic-h3/src/client.rs
@@ -1,3 +1,3 @@
-use h3_util::client::H3Connection;
+use h3_util::client::H3Channel as Channel;
 
-pub type H3Channel<C> = H3Connection<C, tonic::body::Body>;
+pub type H3Channel<C> = Channel<C, tonic::body::Body>;

--- a/tonic-h3/src/client.rs
+++ b/tonic-h3/src/client.rs
@@ -1,3 +1,4 @@
 use h3_util::client::H3Channel as Channel;
 
 pub type H3Channel<C> = Channel<C, tonic::body::Body>;
+pub type H3NonBufferedChannel<C> = h3_util::client::H3Connection<C, tonic::body::Body>;

--- a/tonic-h3/src/lib.rs
+++ b/tonic-h3/src/lib.rs
@@ -51,3 +51,5 @@ pub mod msquic {
 pub mod s2n {
     pub use h3_util::s2n::*;
 }
+
+pub use h3_util::executor::SharedExec;

--- a/tonic-h3/src/lib.rs
+++ b/tonic-h3/src/lib.rs
@@ -32,7 +32,7 @@
 
 mod client;
 pub mod server;
-pub use client::H3Channel;
+pub use {client::H3Channel, client::H3NonBufferedChannel};
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 


### PR DESCRIPTION
This pull request introduces a new cloneable, buffered HTTP/3 client channel (`H3Channel`) to enable multiplexing requests, and updates the API to allow passing a custom executor throughout the client stack. It also updates dependencies and refactors usages to support the new channel and executor pattern. The changes improve ergonomics for users who want to send multiple concurrent requests and have more control over execution.

**Major new features:**

* Added `H3Channel` in `h3-util` as a cloneable, buffered HTTP/3 client channel for multiplexing requests. This includes a new `ResponseFuture` type and integration with `tower::buffer` for request buffering. (`h3-util/src/client.rs`)
* Updated the API for constructing client connections and channels to accept an optional `SharedExec` executor, allowing users to customize task execution. (`h3-util/src/client.rs`, `h3-util/src/client_conn.rs`) [[1]](diffhunk://#diff-fa3eb8b54e03487d22d15af955f1b714e9e774305a9aa1f61a5ad3fed3c0b468L69-R203) [[2]](diffhunk://#diff-e903a98a1efde1bbd7ce618a10ce0f09ac88eb185c12da1007f74897b21b5ef5L103-R110)

**Dependency and type updates:**

* Enabled the `buffer` feature for the `tower` dependency to support the new buffered channel. (`Cargo.toml`)
* Updated the type alias `H3Channel` in `tonic-h3` to refer to the new buffered channel, and introduced `H3NonBufferedChannel` for the previous direct connection type. (`tonic-h3/src/client.rs`, `tonic-h3/src/lib.rs`) [[1]](diffhunk://#diff-4e19cfcc5840f09c5da9704ccc88515719cc73fbb99558d3ccf286e4766d4bb5L1-R4) [[2]](diffhunk://#diff-5ba6ca37c10d1b66ff6a7620c164f2bd93a06e1ca4020f75c676223b3f23381eL35-R35)

**Test and example refactoring:**

* Updated all test and example usages to construct channels and connections with the new executor argument and to use the new `H3Channel` type where appropriate. (`tonic-h3-tests/examples/client.rs`, `tonic-h3-tests/examples/mp-client.rs`, `tonic-h3-tests/src/axum.rs`, `tonic-h3-tests/src/cert_error.rs`, `tonic-h3-tests/src/lib.rs`, `tonic-h3-tests/src/mix.rs`, `tonic-h3-tests/src/quiche/mod.rs`, `tonic-h3-tests/src/reconnect.rs`) [[1]](diffhunk://#diff-40176972644d7555d99d8327b36c8287e60e507ac52de9e1d6a3ef2036e141d5L16-R16) [[2]](diffhunk://#diff-e1be444efcb6d0c29f706a5a4a1d4cac9b5f1443b06d58f7aa1094e2ff8c1f1dR1-R40) [[3]](diffhunk://#diff-14da1d57bc90626eb1a6e55c10ac9518f780c3ab5e7d6fe4c44131dea4bcab6bL46-R46) [[4]](diffhunk://#diff-14da1d57bc90626eb1a6e55c10ac9518f780c3ab5e7d6fe4c44131dea4bcab6bL92-R92) [[5]](diffhunk://#diff-41dd6b5c94b5f5ce7576feb0aceb625a4a77ce2b4b1c1be552f03368e971bd42L31-R31) [[6]](diffhunk://#diff-12833b16cf6ddcacf81196c4bd8fc658fbb53aad69c4f3d0c9ffbfddf6c28ca1L625-R625) [[7]](diffhunk://#diff-0459c97cb8c9d2b47f27fa168a2fe9ff6404404f9415518b57d48cebcfa6896fL50-R50) [[8]](diffhunk://#diff-0459c97cb8c9d2b47f27fa168a2fe9ff6404404f9415518b57d48cebcfa6896fL128-R128) [[9]](diffhunk://#diff-0459c97cb8c9d2b47f27fa168a2fe9ff6404404f9415518b57d48cebcfa6896fR153) [[10]](diffhunk://#diff-f38b5bcfde529a78b8a8a25ae4ca3f43e96c73c323c24d44afa2092159c18fc5L67-R67) [[11]](diffhunk://#diff-8d233b084f1fd6af6f2dba5c1c44a431bdecbc444170fafea02696605c9a669bL51-R51)

**Public API improvements:**

* Re-exported `SharedExec` from `tonic-h3` for easier access to executor configuration. (`tonic-h3/src/lib.rs`)

These changes together make the HTTP/3 client channel more flexible, ergonomic, and suitable for concurrent use cases.