### PR TITLE
Fix quinn address failover (MF-1) and buffered channel bricking on transient failures (MF-2)

### DIFF
--- a/docs/client-reconnect-failover-fixes.md
+++ b/docs/client-reconnect-failover-fixes.md
@@ -1,0 +1,110 @@
+# Client Reconnect & Failover Fixes
+
+Two client-path reliability fixes: quinn address failover no longer aborts on the first
+async handshake failure (MF-1), and a transient connect failure no longer permanently
+bricks a buffered `H3Channel` (MF-2).
+
+## MF-1: Try all resolved addresses
+
+`dns_resolve` can return several addresses (e.g. IPv6 + IPv4). `Endpoint::connect()` only
+validates config synchronously; the real handshake completes on the awaited future.
+
+### Previous Design
+
+```rust
+Ok(conn) => {
+    // `?` returns from the whole function on the FIRST async handshake failure,
+    // so later resolved addresses are never tried.
+    let x = conn.await.map_err(Into::<crate::Error>::into)?;
+    return Ok(h3_quinn::Connection::new(x));
+}
+Err(e) => conn_err = e,
+```
+
+### New Design
+
+```rust
+Ok(conn) => match conn.await.map_err(Into::<crate::Error>::into) {
+    Ok(x) => return Ok(h3_quinn::Connection::new(x)),
+    // Record the error and try the next address instead of aborting.
+    Err(e) => conn_err = e,
+},
+Err(e) => conn_err = e,
+```
+
+`Err(conn_err)` is returned only after all addresses are exhausted. The synchronous-error
+arm already continued and is unchanged; the placeholder `conn_err` (`AddrNotAvailable`)
+surfaces only when the resolved list is empty.
+
+## MF-2: Don't brick the buffered channel on a transient failure
+
+`H3Channel` wraps the reconnecting `RequestSender` in `tower::buffer::Buffer`. When the
+inner `poll_ready` returns `Poll::Ready(Err(_))`, the Buffer worker treats it as
+**terminal** — it closes the request channel and replays the stored error to every later
+request and every cloned handle (tower-0.5.3 `src/buffer/worker.rs`). `RequestSender`
+returned connect errors this way, so one transient failure (server not up yet, DNS blip,
+failed reconnect) permanently disabled the channel.
+
+### Fix: defer connect errors to per-request failures (Option A)
+
+`RequestSender` gains `connect_error: Option<crate::Error>`.
+
+`poll_ready` keeps the driver-staleness check, adds an idempotency guard, and stores
+(rather than returns) a connect error:
+
+```rust
+// After the driver-staleness check, before any connect logic:
+if self.connect_error.is_some() {
+    return Poll::Ready(Ok(())); // stay ready; error is surfaced by `call`
+}
+// ...
+Err(e) => {
+    self.make_send_request_fut = None;
+    self.connect_error = Some(e);
+    Ok(()) // NOT Err(e)
+}
+```
+
+`call` surfaces the stored error per-request and never panics on a missing sender:
+
+```rust
+if let Some(e) = self.connect_error.take() {
+    return Box::pin(async move { Err(e) });
+}
+let send_request = match &self.send_request {
+    Some(sr) => sr.clone(),
+    None => return Box::pin(async move { Err(/* not-ready error */) }),
+};
+```
+
+The idempotency guard is required by the tower `Service` contract: repeated `poll_ready`
+calls must stay ready without starting a second connect or dropping the pending error.
+Because `connect_error` is only set when no sender was cached, the invariant
+`connect_error.is_some() ⟹ send_request.is_none()` holds and the cache-hit assertions
+stay valid. After a failure `send_request` stays `None` and `make_send_request_fut` is
+cleared, so once `call` consumes the error the next `poll_ready` starts a fresh connect —
+the channel stays alive and reconnects.
+
+The same shared `RequestSender` backs the non-buffered `H3Connection`; its per-RPC
+behavior is unchanged (connect errors now surface from `call` rather than `poll_ready`).
+
+## Tests
+
+- `tonic-h3-tests/src/buffered_reconnect.rs` — deterministic: a `FailOnce` connector fails
+  its first `connect()` then delegates to a real quinn connector. Asserts a buffered
+  `H3Channel` recovers on a later RPC and its clones are not bricked, and that the
+  non-buffered path recovers too. Without the MF-2 fix the first failure bricks the Buffer
+  and the later requests fail.
+- `tonic-h3-tests/src/failover.rs` — best-effort, environment-guarded: binds the server to
+  `127.0.0.1` and connects via `localhost`; asserts failover when the host resolves to a
+  dual-stack set that can present a failing-first address, and self-skips otherwise (there
+  is no DNS-injection seam without refactoring `dns_resolve`).
+
+## Files Changed
+
+| File | Changes |
+|---|---|
+| `h3-util/src/quinn/client.rs` | `connect` loops over all resolved addresses; async handshake errors continue instead of returning |
+| `h3-util/src/client_conn.rs` | `RequestSender` gains `connect_error`; `poll_ready` idempotency guard + non-terminal connect errors; `call` surfaces the error and drops the `unwrap()` panic |
+| `tonic-h3-tests/src/buffered_reconnect.rs` | New deterministic MF-2 regression tests (buffered + clone + non-buffered) |
+| `tonic-h3-tests/src/failover.rs` | New environment-guarded MF-1 failover test |

--- a/h3-util/src/client_conn.rs
+++ b/h3-util/src/client_conn.rs
@@ -94,6 +94,12 @@ pub struct RequestSender<CONN: H3Connector> {
     >,
     uri: Uri,
     executor: SharedExec,
+    // Stores a connect/handshake error from `poll_ready` so it can be surfaced as a
+    // per-request failure from `call` instead of a terminal readiness error. Returning
+    // an error from `poll_ready` would cause `tower::buffer::Buffer` to treat the channel
+    // as permanently failed (it closes the request channel and replays the stored error
+    // to every subsequent request and cloned handle), which would defeat reconnection.
+    connect_error: Option<crate::Error>,
 }
 
 impl<CONN> RequestSender<CONN>
@@ -108,6 +114,7 @@ where
             make_send_request_fut: None,
             uri,
             executor,
+            connect_error: None,
         }
     }
 }
@@ -147,6 +154,16 @@ where
             }
         }
 
+        // Idempotency guard (tower `Service` contract): if a previous connect attempt
+        // failed, we are "ready" — the stored error will be surfaced by the next `call`.
+        // Returning ready here (before any connect logic) ensures repeated `poll_ready`
+        // calls stay ready and do NOT start a second connect attempt or clear/overwrite
+        // the pending error. The error is cleared only when `call` consumes it, after
+        // which the next `poll_ready` (guard sees `None`) starts a fresh connect attempt.
+        if self.connect_error.is_some() {
+            return std::task::Poll::Ready(Ok(()));
+        }
+
         // ready for send.
         if self.send_request.is_some() {
             tracing::trace!("exp poll_ready cache hit.");
@@ -183,15 +200,40 @@ where
                     Ok(())
                 }
                 Err(e) => {
+                    // Defer the connect/handshake error to the next `call` instead of
+                    // returning it here. Surfacing it through `poll_ready` would make
+                    // `tower::Buffer` permanently fail the channel (see `connect_error`).
+                    // `send_request` stays `None` and `make_send_request_fut` is cleared,
+                    // so once `call` consumes the error the next `poll_ready` reconnects.
                     self.make_send_request_fut = None;
-                    Err(e)
+                    self.connect_error = Some(e);
+                    Ok(())
                 }
             })
     }
 
     /// Gets the send_request from the cache and send the request.
     fn call(&mut self, mut req: Request<B>) -> Self::Future {
-        let send_request = self.send_request.clone().unwrap();
+        // Surface any deferred connect/handshake error as a per-request failure. `take`
+        // moves the error out, so the next `poll_ready` will start a fresh connect.
+        if let Some(e) = self.connect_error.take() {
+            return Box::pin(async move { Err(e) });
+        }
+
+        // Defensive: under the tower `Service` contract `call` is only reached after a
+        // `poll_ready` that returned `Ready(Ok)`, which means either a cached sender or a
+        // pending connect error existed. If neither holds (contract violation), return an
+        // error future rather than panicking.
+        let send_request = match &self.send_request {
+            Some(sr) => sr.clone(),
+            None => {
+                return Box::pin(async move {
+                    Err(crate::Error::from(
+                        "h3 request sender is not ready: poll_ready must return Ready(Ok) before call",
+                    ))
+                });
+            }
+        };
 
         // replace the uri
         let uri = &self.uri;

--- a/h3-util/src/quinn/client.rs
+++ b/h3-util/src/quinn/client.rs
@@ -37,10 +37,18 @@ impl H3Connector for H3QuinnConnector {
                 .connect(addr, &self.server_name)
                 .map_err(Into::<crate::Error>::into)
             {
-                Ok(conn) => {
-                    let x = conn.await.map_err(Into::<crate::Error>::into)?;
-                    return Ok(h3_quinn::Connection::new(x));
-                }
+                // `Endpoint::connect` only validates config synchronously; the real
+                // handshake completes on the awaited future below.
+                Ok(conn) => match conn.await.map_err(Into::<crate::Error>::into) {
+                    Ok(x) => return Ok(h3_quinn::Connection::new(x)),
+                    // The async handshake failed for this address. Record the error and
+                    // continue to the next resolved address (e.g. IPv6 then IPv4) rather
+                    // than aborting the whole connect attempt on the first failure.
+                    Err(e) => {
+                        tracing::trace!("handshake failed for {addr:?}: {e}");
+                        conn_err = e;
+                    }
+                },
                 Err(e) => conn_err = e,
             }
         }

--- a/tonic-h3-tests/src/buffered_reconnect.rs
+++ b/tonic-h3-tests/src/buffered_reconnect.rs
@@ -1,0 +1,184 @@
+//! Regression test for MF-2: a transient connect/DNS failure must NOT permanently
+//! brick a buffered `H3Channel` (nor its clones), and the non-buffered path must keep
+//! surfacing connect failures per-request while remaining able to reconnect.
+//!
+//! `H3Channel` wraps the reconnecting `RequestSender` in `tower::buffer::Buffer`. Before
+//! the fix, `RequestSender::poll_ready` returned a transient connect error as a readiness
+//! error; the Buffer worker treats a readiness error as terminal — it closes the request
+//! channel and replays the stored error to every later request and every cloned handle
+//! forever. The fix defers connect errors to per-request failures (`connect_error`), so
+//! the channel stays alive and reconnects on the next request.
+//!
+//! These tests are deterministic: a `FailOnce` connector fails its first `connect()` and
+//! then delegates to a real quinn connector, so "server is briefly unreachable then
+//! reachable" is reproduced without any timing/port races.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use h3_util::client::H3Connector;
+use http::{Request, Uri};
+use tokio_util::sync::CancellationToken;
+
+/// An `H3Connector` wrapper whose first `connect()` call fails with a simulated transient
+/// error and whose subsequent calls delegate to the inner (real) connector. All
+/// associated stream types are delegated to the inner connector.
+#[derive(Clone)]
+struct FailOnce<C: H3Connector> {
+    inner: C,
+    failed: Arc<AtomicBool>,
+}
+
+impl<C: H3Connector> FailOnce<C> {
+    fn new(inner: C) -> Self {
+        Self {
+            inner,
+            failed: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl<C: H3Connector> H3Connector for FailOnce<C> {
+    type CONN = C::CONN;
+    type OS = C::OS;
+    type SS = C::SS;
+    type RS = C::RS;
+    type BS = C::BS;
+
+    fn connect(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Self::CONN, h3_util::Error>> + Send {
+        // Move owned clones into the future so it is `Send` without requiring `Sync`
+        // (the future must not borrow `&self` across the await point).
+        let failed = self.failed.clone();
+        let inner = self.inner.clone();
+        async move {
+            // `swap` returns the previous value: the first call sees `false` and fails;
+            // every later call sees `true` and delegates to the real connector.
+            if !failed.swap(true, Ordering::SeqCst) {
+                tracing::debug!("FailOnce: injecting simulated transient connect failure");
+                return Err("simulated transient connect failure".into());
+            }
+            inner.connect().await
+        }
+    }
+}
+
+/// SC-002 / SC-003: a buffered `H3Channel` survives a transient connect failure — the
+/// first RPC fails, a later RPC on the same channel succeeds, and clones are not bricked.
+#[tokio::test]
+#[test_log::test]
+async fn quinn_buffered_channel_survives_transient_failure() {
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let token = CancellationToken::new();
+    let (h_svr, listen_addr) = crate::run_test_quinn_hello_server(addr, token.clone());
+
+    // Let the server come up.
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let uri: Uri = format!("https://localhost:{}", listen_addr.port())
+        .parse()
+        .unwrap();
+    let client_endpoint = crate::make_test_quinn_client_endpoint();
+    let real = tonic_h3::quinn::H3QuinnConnector::new(
+        uri.clone(),
+        "localhost".to_string(),
+        client_endpoint.clone(),
+    );
+    let cc = FailOnce::new(real);
+    let channel = tonic_h3::H3Channel::new(cc, uri, None);
+    let mut client = crate::greeter_client::GreeterClient::new(channel.clone());
+
+    // First RPC: the injected transient connect failure surfaces as a per-request error.
+    let first = client
+        .say_hello(tonic::Request::new(crate::HelloRequest {
+            name: "one".into(),
+        }))
+        .await;
+    assert!(
+        first.is_err(),
+        "expected first RPC to fail with the transient connect error, got {first:?}"
+    );
+    tracing::debug!("first RPC error (expected): {:?}", first.unwrap_err());
+
+    // Second RPC on the SAME channel: the channel is not bricked and reconnects.
+    let second = client
+        .say_hello(tonic::Request::new(crate::HelloRequest {
+            name: "two".into(),
+        }))
+        .await
+        .expect("expected second RPC on the same channel to succeed after reconnect");
+    tracing::debug!("second RPC response: {second:?}");
+
+    // SC-003: a clone taken after the transient failure is also healthy.
+    let mut cloned_client = crate::greeter_client::GreeterClient::new(channel.clone());
+    let via_clone = cloned_client
+        .say_hello(tonic::Request::new(crate::HelloRequest {
+            name: "clone".into(),
+        }))
+        .await
+        .expect("expected a cloned channel handle to serve requests (not bricked)");
+    tracing::debug!("clone RPC response: {via_clone:?}");
+
+    // Cleanup.
+    client_endpoint.close(0_u16.into(), b"client close");
+    token.cancel();
+    h_svr.await.unwrap();
+}
+
+/// FR-008: the non-buffered `H3Connection` path (shared `RequestSender`, no Buffer) keeps
+/// surfacing connect failures per-request and recovers on a subsequent request. This
+/// confirms the MF-2 change does not regress the non-buffered path's observable behavior.
+#[tokio::test]
+#[test_log::test]
+async fn quinn_non_buffered_survives_transient_failure() {
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let token = CancellationToken::new();
+    let (h_svr, listen_addr) = crate::run_test_quinn_hello_server(addr, token.clone());
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let uri: Uri = format!("https://localhost:{}", listen_addr.port())
+        .parse()
+        .unwrap();
+    let client_endpoint = crate::make_test_quinn_client_endpoint();
+    let real = tonic_h3::quinn::H3QuinnConnector::new(
+        uri.clone(),
+        "localhost".to_string(),
+        client_endpoint.clone(),
+    );
+    let cc = FailOnce::new(real);
+    let channel = h3_util::client::H3Connection::new(cc, uri.clone(), None);
+    let mut client = h3_util::client::H3Client::new(channel);
+
+    let build_req = || {
+        Request::builder()
+            .method("POST")
+            .uri(uri.clone())
+            .body(http_body_util::Empty::<hyper::body::Bytes>::new())
+            .unwrap()
+    };
+
+    // First request: transient connect failure surfaces as a per-request error.
+    let first = client.send(build_req()).await;
+    assert!(
+        first.is_err(),
+        "expected first non-buffered request to fail with the transient connect error"
+    );
+    tracing::debug!("non-buffered first error (expected): {:?}", first.err());
+
+    // Second request: the shared RequestSender reconnects and the HTTP/3 exchange
+    // completes (a transport-level response is returned regardless of gRPC status).
+    let second = client.send(build_req()).await;
+    assert!(
+        second.is_ok(),
+        "expected second non-buffered request to succeed after reconnect, got {:?}",
+        second.err()
+    );
+    tracing::debug!("non-buffered second request succeeded");
+
+    // Cleanup.
+    client_endpoint.close(0_u16.into(), b"client close");
+    token.cancel();
+    h_svr.await.unwrap();
+}

--- a/tonic-h3-tests/src/failover.rs
+++ b/tonic-h3-tests/src/failover.rs
@@ -1,0 +1,97 @@
+//! Regression test for MF-1: quinn address failover must try every DNS-resolved
+//! address before giving up, rather than aborting on the first asynchronous
+//! handshake failure.
+//!
+//! This is a best-effort, environment-guarded full-stack test. The quinn connector
+//! sources its address list from `dns_resolve` (there is no injection seam without
+//! refactoring it, which is out of scope), so the only way to exercise the real
+//! `H3QuinnConnector::connect` loop is via a host name that resolves to multiple
+//! addresses. We bind the server to `127.0.0.1` only and connect via `localhost`.
+//! When `localhost` resolves to a dual-stack set (e.g. `[::1, 127.0.0.1]`) with the
+//! non-loopback-v4 address ordered first, the first handshake fails and the fix must
+//! continue to `127.0.0.1`. If the environment resolves `localhost` to a single
+//! address, the failover path cannot be exercised and the test self-skips (logs and
+//! returns) instead of producing a flaky failure.
+
+use std::sync::Arc;
+
+use h3_util::quinn::h3_quinn::quinn;
+
+#[tokio::test]
+#[test_log::test]
+async fn quinn_multi_address_failover() {
+    let bind_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let token = tokio_util::sync::CancellationToken::new();
+
+    // Server listens on 127.0.0.1 only.
+    let (h_svr, listen_addr) = crate::run_test_quinn_hello_server(bind_addr, token.clone());
+    let port = listen_addr.port();
+
+    // Give the server a moment to come up.
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // Resolve `localhost:<port>` to inspect what the connector's `dns_resolve` will see.
+    let resolved: Vec<std::net::SocketAddr> = tokio::net::lookup_host(format!("localhost:{port}"))
+        .await
+        .expect("lookup_host localhost failed")
+        .collect();
+    tracing::info!("localhost:{port} resolved to: {resolved:?}");
+
+    let exercises_failover = resolved.len() >= 2
+        && resolved
+            .iter()
+            .any(|a| a.ip() != std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+
+    if !exercises_failover {
+        tracing::warn!(
+            "skipping MF-1 failover assertion: `localhost` resolved to {resolved:?}, \
+             which cannot exercise a failing-first address on this host"
+        );
+        // Clean up server and pass — the environment cannot exercise failover.
+        token.cancel();
+        h_svr.await.unwrap();
+        return;
+    }
+
+    // Build a client endpoint with a short idle timeout so a failing-first address
+    // (e.g. `::1` where nothing listens) fails fast instead of stalling the test.
+    let client_endpoint = make_short_idle_quinn_client_endpoint();
+    let uri: http::Uri = format!("https://localhost:{port}").parse().unwrap();
+    let cc = tonic_h3::quinn::H3QuinnConnector::new(
+        uri.clone(),
+        "localhost".to_string(),
+        client_endpoint.clone(),
+    );
+    let channel = tonic_h3::H3Channel::new(cc, uri, None);
+    let mut client = crate::greeter_client::GreeterClient::new(channel);
+
+    // A single call must succeed by failing over to the healthy 127.0.0.1 address.
+    let request = tonic::Request::new(crate::HelloRequest {
+        name: "Failover".into(),
+    });
+    let response = client
+        .say_hello(request)
+        .await
+        .expect("expected failover to a healthy address to succeed");
+    tracing::debug!("failover RESPONSE={response:?}");
+
+    // Cleanup.
+    client_endpoint.close(0_u16.into(), b"client close");
+    token.cancel();
+    h_svr.await.unwrap();
+}
+
+/// A dual-stack quinn client endpoint (skips cert verification for tests) with a short
+/// idle timeout, so a handshake to a dead address fails promptly.
+fn make_short_idle_quinn_client_endpoint() -> quinn::Endpoint {
+    let tls_config = crate::make_danger_rustls_client_config();
+    let mut client_endpoint = quinn::Endpoint::client("[::]:0".parse().unwrap()).unwrap();
+    let mut client_config = quinn::ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(tls_config).unwrap(),
+    ));
+    let mut transport = quinn::TransportConfig::default();
+    transport.max_idle_timeout(Some(std::time::Duration::from_secs(2).try_into().unwrap()));
+    client_config.transport_config(Arc::new(transport));
+    client_endpoint.set_default_client_config(client_config);
+    client_endpoint
+}

--- a/tonic-h3-tests/src/lib.rs
+++ b/tonic-h3-tests/src/lib.rs
@@ -28,6 +28,9 @@ mod cert_error;
 #[cfg(test)]
 mod failover;
 
+#[cfg(test)]
+mod buffered_reconnect;
+
 pub mod cert_gen;
 
 tonic::include_proto!("helloworld"); // The string specified here must match the proto package name

--- a/tonic-h3-tests/src/lib.rs
+++ b/tonic-h3-tests/src/lib.rs
@@ -25,6 +25,9 @@ mod mix;
 #[cfg(test)]
 mod cert_error;
 
+#[cfg(test)]
+mod failover;
+
 pub mod cert_gen;
 
 tonic::include_proto!("helloworld"); // The string specified here must match the proto package name


### PR DESCRIPTION
## Summary
Fixes two verified must-fix client-reliability bugs in the quinn HTTP/3 path (from the Society-of-Thought review under `.paw/reviews/crates-deep-review/`). Changes are minimal and surgical; scope is strictly MF-1 and MF-2. MF-3 and MF-4 are intentionally deferred.

## Changes
- **MF-1 — `h3-util/src/quinn/client.rs` (`H3QuinnConnector::connect`)**: The address loop now tries *all* DNS-resolved addresses. An async handshake failure (`conn.await`) is captured into `conn_err` and the loop `continue`s to the next address; the function returns `Err(conn_err)` only after every address is exhausted. Previously the `?` on the first async handshake failure aborted the whole connect, so a dead first address (e.g. IPv6 before IPv4) was fatal even when a later address would succeed.
- **MF-2 — `h3-util/src/client_conn.rs` (`RequestSender`)**: Connect errors are now deferred to per-request failures instead of being surfaced through `poll_ready`. tower's `Buffer` treats a `poll_ready` error as terminal (it closes the channel and replays the error to every future request and every clone), so a single transient connect/DNS failure permanently bricked the buffered `H3Channel`. Fix (Option A): added a `connect_error: Option<crate::Error>` field; `poll_ready` now returns `Ready(Ok(()))` on a failed connect (storing the error) and has an idempotency guard so repeated polls stay ready without starting a second connect; `call` takes the stored error and returns it as a per-request failure (no `.unwrap()` panic). After a failure the sender stays uncached, so the next `poll_ready` starts a fresh connect — the channel keeps reconnecting.

## Testing
- `cargo clippy -p tonic-h3 -p axum-h3 -p h3-util --features tonic-h3/quinn,h3-util/quinn` — clean
- `cargo build` — clean
- Targeted tests (5 passed, 0 failed):
  - `buffered_reconnect::quinn_buffered_channel_survives_transient_failure` (MF-2, buffered + clone)
  - `buffered_reconnect::quinn_non_buffered_survives_transient_failure`
  - `failover::quinn_multi_address_failover` (MF-1)
  - `cert_error::quinn_cert_error_no_panic` — no regression
  - `reconnect::h3_quinn_test` — no regression

## Breaking changes
None. Public API unchanged; behavior change is limited to reconnect/failover robustness on the quinn path.

## Out of scope (deferred)
- MF-3 (interrupted body-send appears as graceful FIN vs HTTP/3 reset) — needs deliberate `stop_stream`/reset semantics + protocol tests.
- MF-4 (unbounded task spawning) — largely bounded by the caller-supplied quinn `Endpoint`; proper fix is a limits/backpressure API.

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)
