### PR TITLE
[Send Stream Reset (MF-3)] Reset HTTP/3 streams on interrupted body sends

### DIFF
--- a/docs/send-stream-reset-mf3.md
+++ b/docs/send-stream-reset-mf3.md
@@ -1,0 +1,94 @@
+# Resetting HTTP/3 Streams on Interrupted Body Sends
+
+Interrupted request/response body sends now reset the HTTP/3 stream so the peer
+observes a stream error instead of a graceful end-of-stream.
+
+## The Problem
+
+`send_h3_client_body` / `send_h3_server_body` own (client) or borrow (server) the
+send half of an h3 `RequestStream`. When a body send was interrupted, the send
+half was simply dropped without being reset.
+
+On the production `quinn` backend, dropping an unfinished `SendStream` implicitly
+calls `finish()` (quinn `send_stream.rs`, `impl Drop for SendStream`). The peer
+therefore sees a clean `FIN` — "message complete" — instead of a cancel/reset.
+A **truncated** request or response could be processed as if it were complete.
+This is dangerous for client-streaming / bidirectional RPCs and for cancellation:
+
+- **Cancellation** (interrupt path A): the client body-send future is eagerly
+  polled and then detached as a background task (`client_conn.rs`). Cancelling
+  the RPC dropped that task; the un-reset stream FIN-ed.
+- **Local body-source error** (path B): `body.poll_frame` yields `Err(..)`.
+- **Transport send error** (path C): `send_data` / `send_trailers` / `finish`
+  fails.
+
+The send-side `RequestStream` exposes a synchronous
+`stop_stream(error_code: h3::error::Code)` that resets the sending part — but
+explicit `?`/`select!` branches cannot cover the case where the whole future is
+dropped or its task aborted.
+
+## The Fix: A Reset-on-Drop Guard
+
+`h3-util/src/send_guard.rs` introduces `SendResetGuard<W>`, an RAII guard around
+the send-side stream:
+
+- It is created **armed** with the default code `H3_REQUEST_CANCELLED`.
+- It `Deref`s to the wrapped stream, so `send_data` / `send_trailers` / `finish`
+  go through it unchanged.
+- On `Drop`, if still armed, it calls `stop_stream(code)` (best-effort; a no-op
+  if the stream is already finished or reset).
+- On **normal completion**, the caller disarms it *after* `finish()` succeeds, so
+  a completed stream is never spuriously reset.
+
+Because the guard owns (client) or mutably borrows (server) the stream, a hard
+drop or task abort still runs `Drop` and resets the stream — the crux that
+branch-only handling misses.
+
+### Error-Code Mapping
+
+The two failure classes are deliberately **not** collapsed:
+
+| Interrupt                                   | Reset code             |
+| ------------------------------------------- | ---------------------- |
+| Deliberate cancellation (path A)            | `H3_REQUEST_CANCELLED` |
+| Local body-source / transport send (B, C)   | `H3_INTERNAL_ERROR`    |
+
+Cancellation returns `Ok(())` with the guard still armed at its default code.
+Error paths call `set_error_code(H3_INTERNAL_ERROR)` before returning `Err`.
+
+## Receive-Side Reset on Incomplete Drop
+
+The incoming bodies (`H3IncomingClient`, `H3IncomingServer`) had the mirror-image
+problem: dropping one before the stream was fully consumed left quinn to send
+`STOP_SENDING` with code `0`, which is not a valid HTTP/3 error code.
+
+Each now tracks a `finished` flag, set when the body reaches a terminal state
+(clean end-of-stream or a stream error). A `Drop` impl calls
+`stop_sending(H3_REQUEST_CANCELLED)` only when the body was **not** fully
+consumed. Fully-read streams — the normal unary/streaming case, where gRPC always
+reads trailers — are never reset, so there is no behavior change for completed
+RPCs.
+
+## Tests
+
+`tonic-h3-tests/src/cancel_reset.rs` exercises the production quinn path through
+the raw `h3-util` client and an `axum-h3` server that reports the terminal
+outcome of reading the request body (clean EOF vs. stream error):
+
+- `client_body_error_resets_stream` — a body-source failure mid-upload → the
+  server observes a reset carrying `H3_INTERNAL_ERROR`.
+- `client_cancel_resets_stream` — cancelling an in-flight upload (dropping the
+  response) → the server observes a reset carrying `H3_REQUEST_CANCELLED`.
+- `normal_upload_completes_cleanly` — a body that completes normally → the server
+  sees a graceful end-of-stream (guards against spurious resets).
+
+## Files Changed
+
+- `h3-util/src/send_guard.rs` (new) — `SendResetGuard` and the `StopSendStream`
+  trait.
+- `h3-util/src/client_body.rs` — wire the guard into `send_h3_client_body`;
+  recv-side `Drop` on `H3IncomingClient`.
+- `h3-util/src/server_body.rs` — wire the guard into `send_h3_server_body`;
+  recv-side `Drop` on `H3IncomingServer`.
+- `h3-util/src/lib.rs` — register the `send_guard` module.
+- `tonic-h3-tests/src/cancel_reset.rs` (new) — integration tests.

--- a/h3-util/src/client_body.rs
+++ b/h3-util/src/client_body.rs
@@ -107,6 +107,16 @@ where
     }
 }
 
+/// Stream the client request body to the peer over the send-side
+/// `RequestStream`.
+///
+/// The send stream is wrapped in a reset-on-drop guard: if the body send is
+/// interrupted — by cancellation, a local body-source error, a transport send
+/// error, or a hard drop/abort of this future — the stream is reset so the peer
+/// observes an HTTP/3 stream error instead of a graceful end-of-stream.
+/// Cancellation resets with `H3_REQUEST_CANCELLED`; body-source and transport
+/// failures reset with `H3_INTERNAL_ERROR`. On normal completion the guard is
+/// disarmed after `finish()` succeeds, preserving the clean FIN.
 pub async fn send_h3_client_body<S, B>(
     w: h3::client::RequestStream<<S as h3::quic::BidiStream<Bytes>>::SendStream, Bytes>,
     bd: B,

--- a/h3-util/src/client_body.rs
+++ b/h3-util/src/client_body.rs
@@ -77,7 +77,7 @@ where
 }
 
 pub async fn send_h3_client_body<S, B>(
-    mut w: h3::client::RequestStream<<S as h3::quic::BidiStream<Bytes>>::SendStream, Bytes>,
+    w: h3::client::RequestStream<<S as h3::quic::BidiStream<Bytes>>::SendStream, Bytes>,
     bd: B,
     mut cancel: tokio::sync::oneshot::Receiver<()>,
 ) -> Result<(), crate::Error>
@@ -87,29 +87,52 @@ where
     B::Data: Send,
     B::Error: Into<crate::Error>,
 {
+    // Reset-on-drop guard: if this future is cancelled, errors, or is dropped/
+    // aborted before `finish()` succeeds, the send stream is reset so the peer
+    // observes an HTTP/3 stream error instead of a graceful end-of-stream.
+    let mut w = crate::send_guard::SendResetGuard::new(w);
     let mut p_b = std::pin::pin!(bd);
     loop {
         let frame = tokio::select! {
             biased;
             _ = &mut cancel => {
                 tracing::trace!("client body send cancelled");
+                // Guard stays armed with H3_REQUEST_CANCELLED; drop resets.
                 return Ok(());
             }
             frame = futures::future::poll_fn(|cx| p_b.as_mut().poll_frame(cx)) => frame,
         };
 
         let Some(d) = frame else { break };
-        let d = d.map_err(|e| e.into())?;
+        let d = match d {
+            Ok(d) => d,
+            Err(e) => {
+                // Local body-source failure: reset with an internal error.
+                w.set_error_code(h3::error::Code::H3_INTERNAL_ERROR);
+                return Err(e.into());
+            }
+        };
         if d.is_data() {
             let mut d = d.into_data().ok().unwrap();
             tracing::trace!("client write data");
-            w.send_data(d.copy_to_bytes(d.remaining())).await?;
+            if let Err(e) = w.send_data(d.copy_to_bytes(d.remaining())).await {
+                w.set_error_code(h3::error::Code::H3_INTERNAL_ERROR);
+                return Err(e.into());
+            }
         } else if d.is_trailers() {
             let d = d.into_trailers().ok().unwrap();
             tracing::trace!("client write trailer: {:?}", d);
-            w.send_trailers(d).await?;
+            if let Err(e) = w.send_trailers(d).await {
+                w.set_error_code(h3::error::Code::H3_INTERNAL_ERROR);
+                return Err(e.into());
+            }
         }
     }
-    w.finish().await?;
+    if let Err(e) = w.finish().await {
+        w.set_error_code(h3::error::Code::H3_INTERNAL_ERROR);
+        return Err(e.into());
+    }
+    // Normal completion: keep the graceful FIN, do not reset on drop.
+    w.disarm();
     Ok(())
 }

--- a/h3-util/src/client_body.rs
+++ b/h3-util/src/client_body.rs
@@ -8,6 +8,10 @@ where
 {
     s: RequestStream<S, B>,
     data_done: bool,
+    // Set once the stream reaches its terminal state (clean end-of-stream or a
+    // stream error). Used by `Drop` to decide whether an early drop should reset
+    // the receive side.
+    finished: bool,
     // Dropping this sender cancels the background body send task.
     _cancel_body_send: Option<tokio::sync::oneshot::Sender<()>>,
 }
@@ -24,7 +28,24 @@ where
         Self {
             s,
             data_done: false,
+            finished: false,
             _cancel_body_send: cancel_body_send,
+        }
+    }
+}
+
+impl<S, B> Drop for H3IncomingClient<S, B>
+where
+    B: Buf,
+    S: h3::quic::RecvStream,
+{
+    fn drop(&mut self) {
+        if !self.finished {
+            // The incoming response body was dropped before it was fully
+            // consumed. Tell the peer to stop sending with a proper HTTP/3 code
+            // (quinn would otherwise send STOP_SENDING with code 0). Best-effort:
+            // ignored if the stream is already finished or reset.
+            self.s.stop_sending(h3::error::Code::H3_REQUEST_CANCELLED);
         }
     }
 }
@@ -56,13 +77,23 @@ where
                         std::task::Poll::Pending
                     }
                 },
-                Err(e) => std::task::Poll::Ready(Some(Err(e))),
+                Err(e) => {
+                    self.finished = true;
+                    std::task::Poll::Ready(Some(Err(e)))
+                }
             }
         } else {
             // TODO: need poll trailers api.
-            match futures::ready!(self.s.poll_recv_trailers(cx))? {
-                Some(tr) => std::task::Poll::Ready(Some(Ok(hyper::body::Frame::trailers(tr)))),
-                None => std::task::Poll::Ready(None),
+            match futures::ready!(self.s.poll_recv_trailers(cx)) {
+                Ok(Some(tr)) => std::task::Poll::Ready(Some(Ok(hyper::body::Frame::trailers(tr)))),
+                Ok(None) => {
+                    self.finished = true;
+                    std::task::Poll::Ready(None)
+                }
+                Err(e) => {
+                    self.finished = true;
+                    std::task::Poll::Ready(Some(Err(e)))
+                }
             }
         }
     }

--- a/h3-util/src/lib.rs
+++ b/h3-util/src/lib.rs
@@ -42,6 +42,7 @@ pub mod executor;
 pub mod msquic;
 #[cfg(feature = "quinn")]
 pub mod quinn;
+mod send_guard;
 pub mod server;
 pub mod server_body;
 

--- a/h3-util/src/send_guard.rs
+++ b/h3-util/src/send_guard.rs
@@ -1,0 +1,113 @@
+//! Reset-on-drop guard for HTTP/3 send-side [`RequestStream`]s.
+//!
+//! When a request/response body send is interrupted — by cancellation, a local
+//! body-source error, a transport send error, or a hard drop/abort of the
+//! body-send future — the send-side stream must be *reset* so the peer observes
+//! an HTTP/3 stream error rather than a graceful end-of-stream. Without an
+//! explicit reset, dropping an unfinished Quinn `SendStream` implicitly calls
+//! `finish()`, which the peer sees as a clean FIN, allowing a truncated message
+//! to be processed as if it were complete.
+//!
+//! [`SendResetGuard`] wraps the send half and calls
+//! [`stop_stream`](h3::client::RequestStream::stop_stream) on drop while it is
+//! *armed*. Callers disarm it only after a normal `finish()` succeeds, so a
+//! completed stream is never spuriously reset.
+//!
+//! [`RequestStream`]: h3::client::RequestStream
+
+use h3::error::Code;
+use hyper::body::Buf;
+
+/// Send-side HTTP/3 streams that can be reset with an error code.
+///
+/// Implemented for both the client and server `RequestStream` send halves (and
+/// for `&mut` references to them) so a single guard type works for both.
+pub(crate) trait StopSendStream {
+    fn stop_send_stream(&mut self, code: Code);
+}
+
+impl<S, B> StopSendStream for h3::client::RequestStream<S, B>
+where
+    S: h3::quic::SendStream<B>,
+    B: Buf,
+{
+    fn stop_send_stream(&mut self, code: Code) {
+        self.stop_stream(code);
+    }
+}
+
+impl<S, B> StopSendStream for h3::server::RequestStream<S, B>
+where
+    S: h3::quic::SendStream<B>,
+    B: Buf,
+{
+    fn stop_send_stream(&mut self, code: Code) {
+        self.stop_stream(code);
+    }
+}
+
+impl<T: StopSendStream> StopSendStream for &mut T {
+    fn stop_send_stream(&mut self, code: Code) {
+        (**self).stop_send_stream(code);
+    }
+}
+
+/// RAII guard that resets the wrapped send stream on drop unless disarmed.
+///
+/// The guard [`Deref`](std::ops::Deref)s to the wrapped stream, so
+/// `send_data`/`send_trailers`/`finish` are called through it directly.
+///
+/// - Default state is *armed* with [`Code::H3_REQUEST_CANCELLED`].
+/// - Call [`set_error_code`](Self::set_error_code) before returning an error to
+///   reset with a different code (e.g. [`Code::H3_INTERNAL_ERROR`]).
+/// - Call [`disarm`](Self::disarm) after a successful `finish()` so normal
+///   completion leaves the graceful FIN in place.
+pub(crate) struct SendResetGuard<W: StopSendStream> {
+    w: W,
+    armed: bool,
+    code: Code,
+}
+
+impl<W: StopSendStream> SendResetGuard<W> {
+    /// Wrap a send stream, armed to reset with [`Code::H3_REQUEST_CANCELLED`].
+    pub(crate) fn new(w: W) -> Self {
+        Self {
+            w,
+            armed: true,
+            code: Code::H3_REQUEST_CANCELLED,
+        }
+    }
+
+    /// Disarm the guard so drop leaves the stream untouched (normal completion).
+    pub(crate) fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    /// Set the error code used when the guard resets the stream on drop.
+    pub(crate) fn set_error_code(&mut self, code: Code) {
+        self.code = code;
+    }
+}
+
+impl<W: StopSendStream> std::ops::Deref for SendResetGuard<W> {
+    type Target = W;
+
+    fn deref(&self) -> &Self::Target {
+        &self.w
+    }
+}
+
+impl<W: StopSendStream> std::ops::DerefMut for SendResetGuard<W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.w
+    }
+}
+
+impl<W: StopSendStream> Drop for SendResetGuard<W> {
+    fn drop(&mut self) {
+        if self.armed {
+            // Best-effort: a no-op if the stream is already finished or reset.
+            self.w.stop_send_stream(self.code);
+        }
+    }
+}

--- a/h3-util/src/server_body.rs
+++ b/h3-util/src/server_body.rs
@@ -102,6 +102,16 @@ where
     }
 }
 
+/// Stream the server response body to the peer over the send-side
+/// `RequestStream`.
+///
+/// Response headers have already been sent by the caller, so an interrupted body
+/// must reset the stream rather than let the peer see a graceful end-of-stream
+/// for a truncated response. The send stream is wrapped in a reset-on-drop
+/// guard: a body-source or transport failure resets with `H3_INTERNAL_ERROR`,
+/// and a hard drop/abort of this future resets with the default
+/// `H3_REQUEST_CANCELLED`. On normal completion the guard is disarmed after
+/// `finish()` succeeds.
 pub async fn send_h3_server_body<BD, S>(
     w: &mut h3::server::RequestStream<<S as h3::quic::BidiStream<Bytes>>::SendStream, Bytes>,
     bd: BD,

--- a/h3-util/src/server_body.rs
+++ b/h3-util/src/server_body.rs
@@ -8,6 +8,10 @@ where
 {
     s: RequestStream<S, B>,
     data_done: bool,
+    // Set once the stream reaches its terminal state (clean end-of-stream or a
+    // stream error). Used by `Drop` to decide whether an early drop should reset
+    // the receive side.
+    finished: bool,
 }
 
 impl<S, B> H3IncomingServer<S, B>
@@ -19,6 +23,23 @@ where
         Self {
             s,
             data_done: false,
+            finished: false,
+        }
+    }
+}
+
+impl<S, B> Drop for H3IncomingServer<S, B>
+where
+    B: Buf,
+    S: h3::quic::RecvStream,
+{
+    fn drop(&mut self) {
+        if !self.finished {
+            // The incoming request body was dropped before it was fully
+            // consumed. Tell the peer to stop sending with a proper HTTP/3 code
+            // (quinn would otherwise send STOP_SENDING with code 0). Best-effort:
+            // ignored if the stream is already finished or reset.
+            self.s.stop_sending(h3::error::Code::H3_REQUEST_CANCELLED);
         }
     }
 }
@@ -51,13 +72,23 @@ where
                         std::task::Poll::Pending
                     }
                 },
-                Err(e) => std::task::Poll::Ready(Some(Err(e))),
+                Err(e) => {
+                    self.finished = true;
+                    std::task::Poll::Ready(Some(Err(e)))
+                }
             }
         } else {
             tracing::trace!("server incomming poll_frame recv_trailers");
-            match futures::ready!(self.s.poll_recv_trailers(cx))? {
-                Some(tr) => std::task::Poll::Ready(Some(Ok(hyper::body::Frame::trailers(tr)))),
-                None => std::task::Poll::Ready(None),
+            match futures::ready!(self.s.poll_recv_trailers(cx)) {
+                Ok(Some(tr)) => std::task::Poll::Ready(Some(Ok(hyper::body::Frame::trailers(tr)))),
+                Ok(None) => {
+                    self.finished = true;
+                    std::task::Poll::Ready(None)
+                }
+                Err(e) => {
+                    self.finished = true;
+                    std::task::Poll::Ready(Some(Err(e)))
+                }
             }
         }
     }

--- a/h3-util/src/server_body.rs
+++ b/h3-util/src/server_body.rs
@@ -82,24 +82,46 @@ where
     <BD as Body>::Data: Send + Sync,
     S: h3::quic::BidiStream<hyper::body::Bytes>,
 {
+    // Reset-on-drop guard: response headers may already have been sent, so an
+    // interrupted body must reset the stream rather than let the peer see a
+    // graceful end-of-stream for a truncated response.
+    let mut w = crate::send_guard::SendResetGuard::new(w);
     let mut p_b = std::pin::pin!(bd);
     while let Some(d) = futures::future::poll_fn(|cx| p_b.as_mut().poll_frame(cx)).await {
         // send body
-        let d = d.map_err(crate::Error::from)?;
+        let d = match d {
+            Ok(d) => d,
+            Err(e) => {
+                // Local body-source failure: reset with an internal error.
+                w.set_error_code(h3::error::Code::H3_INTERNAL_ERROR);
+                return Err(crate::Error::from(e));
+            }
+        };
         if d.is_data() {
             let mut d = d.into_data().ok().unwrap();
             tracing::trace!("serving request write data");
             // Bytes optimizes the shallow copy.
-            w.send_data(d.copy_to_bytes(d.remaining())).await?;
+            if let Err(e) = w.send_data(d.copy_to_bytes(d.remaining())).await {
+                w.set_error_code(h3::error::Code::H3_INTERNAL_ERROR);
+                return Err(e.into());
+            }
         } else if d.is_trailers() {
             let d = d.into_trailers().ok().unwrap();
             tracing::trace!("serving request write trailer: {:?}", d);
-            w.send_trailers(d).await?;
+            if let Err(e) = w.send_trailers(d).await {
+                w.set_error_code(h3::error::Code::H3_INTERNAL_ERROR);
+                return Err(e.into());
+            }
         }
     }
     // Close the stream gracefully.
     // This is technically only needed when not writing trailers.
     // But msquic-h3 requires stream be gracefully closed all the time.
-    w.finish().await?;
+    if let Err(e) = w.finish().await {
+        w.set_error_code(h3::error::Code::H3_INTERNAL_ERROR);
+        return Err(e.into());
+    }
+    // Normal completion: keep the graceful FIN, do not reset on drop.
+    w.disarm();
     Ok(())
 }

--- a/tonic-h3-tests/src/cancel_reset.rs
+++ b/tonic-h3-tests/src/cancel_reset.rs
@@ -1,0 +1,357 @@
+//! Integration tests for MF-3: interrupted HTTP/3 body sends must reset the
+//! send stream so the peer observes a stream error, not a clean end-of-stream.
+//!
+//! These tests exercise the production `quinn` backend through the raw
+//! `h3-util` client (`H3Client`) and an `axum-h3` server, which gives full
+//! control over the request body and lets the server observe the terminal read
+//! outcome (clean EOF vs stream reset).
+
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::routing::post;
+use http::{Request, Uri};
+use http_body_util::BodyExt;
+use hyper::body::{Body, Frame};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+/// Terminal outcome of the server reading a request body.
+#[derive(Debug)]
+enum ReadOutcome {
+    /// The body ended with a graceful end-of-stream after `usize` frames.
+    CleanEof(usize),
+    /// The body read failed with a stream error (reset); the string carries the
+    /// full error chain so the HTTP/3 error code can be asserted.
+    Error(String),
+}
+
+type OutcomeTx = mpsc::UnboundedSender<ReadOutcome>;
+
+/// Request body that emits one complete data frame, waits briefly so the frame
+/// and request head are flushed to the server, then returns an error to simulate
+/// a local body-source failure (interrupt path B) mid-stream.
+struct FailAfterOneFrame {
+    sent: bool,
+    delay: Option<Pin<Box<tokio::time::Sleep>>>,
+}
+
+impl Body for FailAfterOneFrame {
+    type Data = Bytes;
+    type Error = h3_util::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if !self.sent {
+            self.sent = true;
+            self.delay = Some(Box::pin(tokio::time::sleep(Duration::from_millis(300))));
+            return Poll::Ready(Some(Ok(Frame::data(Bytes::from_static(&[0u8; 512])))));
+        }
+        // Wait until the first frame has certainly been flushed and read by the
+        // server, then fail so the reset is observed mid-stream (not coalesced
+        // with the request head).
+        let delay = self.delay.as_mut().expect("delay armed after first frame");
+        match delay.as_mut().poll(cx) {
+            Poll::Ready(()) => {
+                Poll::Ready(Some(Err("simulated client body-source failure".into())))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Request body that emits one complete data frame and then never completes,
+/// keeping the request stream open until the RPC is cancelled.
+struct OneFrameThenPending {
+    sent: bool,
+}
+
+impl Body for OneFrameThenPending {
+    type Data = Bytes;
+    type Error = h3_util::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if !self.sent {
+            self.sent = true;
+            Poll::Ready(Some(Ok(Frame::data(Bytes::from_static(&[7u8; 512])))))
+        } else {
+            // Never yields `None` and registers no waker: the only way this send
+            // can end is via cancellation, which wakes the body-send select arm.
+            Poll::Pending
+        }
+    }
+}
+
+fn stringify_err(e: &(dyn std::error::Error + 'static)) -> String {
+    let mut s = format!("{e} | {e:?}");
+    let mut src = e.source();
+    while let Some(inner) = src {
+        s.push_str(&format!(" -> {inner} | {inner:?}"));
+        src = inner.source();
+    }
+    s
+}
+
+/// Reads the request body inline and reports the terminal outcome, then
+/// responds. Used when the response should only be produced after the request
+/// body has been consumed.
+async fn read_handler(
+    State(tx): State<OutcomeTx>,
+    req: axum::extract::Request,
+) -> axum::http::StatusCode {
+    let mut body = req.into_body();
+    let mut frames = 0usize;
+    loop {
+        match body.frame().await {
+            Some(Ok(_)) => frames += 1,
+            Some(Err(e)) => {
+                let _ = tx.send(ReadOutcome::Error(stringify_err(&e)));
+                return axum::http::StatusCode::INTERNAL_SERVER_ERROR;
+            }
+            None => {
+                let _ = tx.send(ReadOutcome::CleanEof(frames));
+                return axum::http::StatusCode::OK;
+            }
+        }
+    }
+}
+
+/// Responds immediately and reads the request body on a background task,
+/// reporting the terminal outcome. Used so the client receives response headers
+/// (and thus a droppable response body) while the request upload is still open.
+async fn spawn_read_handler(
+    State(tx): State<OutcomeTx>,
+    req: axum::extract::Request,
+) -> axum::http::StatusCode {
+    let mut body = req.into_body();
+    tokio::spawn(async move {
+        let mut frames = 0usize;
+        loop {
+            match body.frame().await {
+                Some(Ok(_)) => frames += 1,
+                Some(Err(e)) => {
+                    let _ = tx.send(ReadOutcome::Error(stringify_err(&e)));
+                    return;
+                }
+                None => {
+                    let _ = tx.send(ReadOutcome::CleanEof(frames));
+                    return;
+                }
+            }
+        }
+    });
+    axum::http::StatusCode::OK
+}
+
+struct TestServer {
+    listen_addr: SocketAddr,
+    outcomes: mpsc::UnboundedReceiver<ReadOutcome>,
+    token: CancellationToken,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl TestServer {
+    async fn shutdown(self) {
+        self.token.cancel();
+        let _ = tokio::time::timeout(Duration::from_secs(2), self.handle).await;
+    }
+}
+
+/// Start an axum-h3 server over quinn with `/read` (inline) and `/spawn`
+/// (background) upload endpoints reporting their terminal read outcome.
+fn start_server() -> TestServer {
+    let (tx, rx) = mpsc::unbounded_channel::<ReadOutcome>();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let ep = crate::make_quinn_server_endpoint(addr);
+    let listen_addr = ep.local_addr().unwrap();
+    let acceptor = h3_util::quinn::H3QuinnAcceptor::new(ep);
+
+    let app = axum::Router::new()
+        .route("/read", post(read_handler))
+        .route("/spawn", post(spawn_read_handler))
+        .with_state(tx);
+
+    let token = CancellationToken::new();
+    let token_cp = token.clone();
+    let handle = tokio::spawn(async move {
+        axum_h3::H3Router::new(app)
+            .serve_with_shutdown(acceptor, async move { token_cp.cancelled().await })
+            .await
+            .unwrap();
+    });
+
+    TestServer {
+        listen_addr,
+        outcomes: rx,
+        token,
+        handle,
+    }
+}
+
+/// Build a raw `H3Client` over quinn for the given server address.
+macro_rules! make_client {
+    ($listen_addr:expr) => {{
+        let uri: Uri = format!("https://{}", $listen_addr).parse().unwrap();
+        let client_endpoint = crate::make_test_quinn_client_endpoint();
+        let cc = h3_util::quinn::H3QuinnConnector::new(
+            uri.clone(),
+            "localhost".to_string(),
+            client_endpoint.clone(),
+        );
+        let channel = h3_util::client::H3Connection::new(cc, uri, None);
+        (client_endpoint, h3_util::client::H3Client::new(channel))
+    }};
+}
+
+/// Primary: a local body-source error mid-upload must reset the send stream so
+/// the server observes a stream error (with `H3_INTERNAL_ERROR`), not clean EOF.
+#[tokio::test]
+#[test_log::test]
+async fn client_body_error_resets_stream() {
+    let mut server = start_server();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let (client_endpoint, mut client) = make_client!(server.listen_addr);
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("https://{}/spawn", server.listen_addr))
+        .body(FailAfterOneFrame {
+            sent: false,
+            delay: None,
+        })
+        .unwrap();
+
+    // Hold the response alive so cancellation (which fires when the response is
+    // dropped) does NOT pre-empt the body-source error; we want to prove the
+    // body-source failure path resets with `H3_INTERNAL_ERROR`.
+    let resp = tokio::time::timeout(Duration::from_secs(5), client.send(req))
+        .await
+        .expect("send timed out")
+        .expect("send failed");
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), server.outcomes.recv())
+        .await
+        .expect("timed out waiting for server read outcome")
+        .expect("server outcome channel closed");
+
+    match &outcome {
+        ReadOutcome::Error(s) => {
+            assert!(
+                s.contains("H3_INTERNAL_ERROR"),
+                "expected internal-error reset code, got: {s}"
+            );
+        }
+        ReadOutcome::CleanEof(n) => {
+            panic!(
+                "interrupted body must reset the stream, but server saw a clean EOF after {n} frames"
+            );
+        }
+    }
+
+    drop(resp);
+    client_endpoint.wait_idle().await;
+    server.shutdown().await;
+}
+
+/// Primary: cancelling an in-flight upload (dropping the response body) must
+/// reset the send stream with `H3_REQUEST_CANCELLED`, so the server observes a
+/// stream error rather than a clean EOF for the truncated request.
+#[tokio::test]
+#[test_log::test]
+async fn client_cancel_resets_stream() {
+    let mut server = start_server();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let (client_endpoint, mut client) = make_client!(server.listen_addr);
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("https://{}/spawn", server.listen_addr))
+        .body(OneFrameThenPending { sent: false })
+        .unwrap();
+
+    // The server responds immediately, so `send` returns a response while the
+    // request upload is still open.
+    let resp = tokio::time::timeout(Duration::from_secs(5), client.send(req))
+        .await
+        .expect("send timed out")
+        .expect("send failed");
+
+    // Let the server begin reading the request body.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Dropping the response drops the cancellation sender, cancelling the
+    // in-flight body send and resetting the request stream.
+    drop(resp);
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), server.outcomes.recv())
+        .await
+        .expect("timed out waiting for server read outcome")
+        .expect("server outcome channel closed");
+
+    match &outcome {
+        ReadOutcome::Error(s) => {
+            assert!(
+                s.contains("H3_REQUEST_CANCELLED"),
+                "expected request-cancelled reset code, got: {s}"
+            );
+        }
+        ReadOutcome::CleanEof(n) => {
+            panic!(
+                "cancelled upload must reset the stream, but server saw a clean EOF after {n} frames"
+            );
+        }
+    }
+
+    client_endpoint.wait_idle().await;
+    server.shutdown().await;
+}
+
+/// Control: a body that completes normally must NOT reset the stream — the
+/// server sees a graceful end-of-stream (guards against spurious resets).
+#[tokio::test]
+#[test_log::test]
+async fn normal_upload_completes_cleanly() {
+    let mut server = start_server();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let body = http_body_util::Full::new(Bytes::from_static(b"hello complete body"))
+        .map_err(|_: std::convert::Infallible| -> h3_util::Error { unreachable!() })
+        .boxed();
+    let (client_endpoint, mut client) = make_client!(server.listen_addr);
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("https://{}/read", server.listen_addr))
+        .body(body)
+        .unwrap();
+
+    let resp = tokio::time::timeout(Duration::from_secs(5), client.send(req))
+        .await
+        .expect("send timed out")
+        .expect("send failed");
+    assert!(resp.status().is_success());
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), server.outcomes.recv())
+        .await
+        .expect("timed out waiting for server read outcome")
+        .expect("server outcome channel closed");
+
+    match &outcome {
+        ReadOutcome::CleanEof(n) => assert!(*n >= 1, "expected at least one data frame, got {n}"),
+        ReadOutcome::Error(s) => {
+            panic!("normal completion must not reset the stream, but server saw error: {s}")
+        }
+    }
+
+    client_endpoint.wait_idle().await;
+    server.shutdown().await;
+}

--- a/tonic-h3-tests/src/lib.rs
+++ b/tonic-h3-tests/src/lib.rs
@@ -31,6 +31,9 @@ mod failover;
 #[cfg(test)]
 mod buffered_reconnect;
 
+#[cfg(test)]
+mod cancel_reset;
+
 pub mod cert_gen;
 
 tonic::include_proto!("helloworld"); // The string specified here must match the proto package name


### PR DESCRIPTION
## Summary

Fixes **MF-3** from the crates deep review: interrupted HTTP/3 body sends were dropped **without** resetting the stream. On the production `quinn` backend, dropping an unfinished `SendStream` implicitly calls `finish()`, so the peer sees a clean `FIN` (message complete) instead of a cancel/reset — allowing a **truncated** request or response to be processed as if it were complete. This is dangerous for client-streaming / bidirectional RPCs and for cancellation.

The fix introduces a RAII **reset-on-drop guard** around the send-side stream, and mirrors the fix on the receive side for incoming bodies dropped before full consumption.

## Changes

**Send side — `SendResetGuard` (`h3-util/src/send_guard.rs`, new)**
- Owns (client) / mutably borrows (server) the send-side `RequestStream` via a small `StopSendStream` trait.
- Armed by default; on `Drop` it calls the synchronous `stop_stream(code)` (best-effort; no-op if already finished/reset). This crucially covers the case where the whole body-send future is **dropped or its task aborted** — the client body-send future is eagerly polled then detached as a background task, so branch-only handling (`?`/`select!`) cannot catch it.
- Disarmed after a successful `finish()`, so normally-completed streams keep their graceful FIN and are never spuriously reset.
- Wired into `send_h3_client_body` and `send_h3_server_body`.

**Error-code mapping (deliberately not collapsed)**
- Deliberate cancellation → `H3_REQUEST_CANCELLED`
- Local body-source failure / transport send failure → `H3_INTERNAL_ERROR`

**Receive side (`H3IncomingClient` / `H3IncomingServer`)**
- Track a `finished` flag set at the terminal state (clean end-of-stream or a stream error).
- `Drop` now calls `stop_sending(H3_REQUEST_CANCELLED)` **only** when the body was not fully consumed, replacing quinn's default `STOP_SENDING` code `0` (an invalid HTTP/3 code). Fully-read streams (the normal gRPC case, which always reads trailers) are never reset, so completed RPCs are unaffected.

## Testing

New quinn integration tests in `tonic-h3-tests/src/cancel_reset.rs` exercise the production path through the raw `h3-util` client and an `axum-h3` server that reports whether reading the request body ended in a clean EOF or a stream error (with the HTTP/3 code):

- `client_body_error_resets_stream` — body-source failure mid-upload → server observes a reset carrying `H3_INTERNAL_ERROR`.
- `client_cancel_resets_stream` — cancelling an in-flight upload → server observes a reset carrying `H3_REQUEST_CANCELLED`.
- `normal_upload_completes_cleanly` — control: normal completion → server sees a graceful end-of-stream (no spurious reset).

Validation:
- `cargo clippy -p tonic-h3 -p axum-h3 -p h3-util --features tonic-h3/quinn,h3-util/quinn` — clean
- `cargo build` — clean
- `cargo doc -p h3-util --no-deps` — clean
- `cargo test -p tonic-h3-test` — **14 passed, 4 environmentally-ignored**, all backends green (quinn, msquic, quiche, s2n). Existing `reconnect`, `cert_error`, `failover`, `buffered_reconnect`, `mix` tests all remain green.

## Breaking Changes

None. Behavior only changes on interrupted/aborted streams (previously a silent FIN, now a proper reset) and on early-dropped incoming bodies (previously `STOP_SENDING` code 0, now `H3_REQUEST_CANCELLED`).

## Notes for Reviewers

- The receive-side `stop_sending` change (Phase 2) was an optional/stretch item; it shipped because it validated cleanly with zero regressions across all backends.
- Design note: `docs/send-stream-reset-mf3.md`.

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>