### PR TITLE
[Client URI GOAWAY Fixes] Client reliability: no URI panics (SF-1) + reconnect after GOAWAY (SF-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,6 +3537,7 @@ dependencies = [
  "axum",
  "axum-h3",
  "futures",
+ "h3",
  "h3-util",
  "http",
  "http-body-util",

--- a/docs/client-uri-goaway-fixes.md
+++ b/docs/client-uri-goaway-fixes.md
@@ -1,0 +1,153 @@
+# Client URI & GOAWAY Reliability Fixes
+
+Two client-path reliability fixes in `h3-util/src/client_conn.rs`, following up on the
+MF-1/MF-2 reconnect/failover work: `RequestSender::call` no longer panics on URIs missing
+components (SF-1), and a peer GOAWAY no longer pins the client to a cached sender that
+rejects every new request forever (SF-3). Both changes are non-breaking — the public
+constructors (`H3Channel::new`, `H3Connection::new`, `H3Client::new`) still return `Self`.
+
+## SF-1: No panic on boundary URIs
+
+`RequestSender::call` rebuilds each outgoing request URI from the channel's base URI
+(scheme + authority, supplied to the public constructors as any `http::Uri`) and the
+request's path-and-query (user/tonic-supplied). The previous code unwrapped every optional
+component, so a base URI missing a scheme/authority, a request URI missing a
+path-and-query, or an invalid rebuilt URI panicked deep inside `tower::Service::call`,
+aborting the request task.
+
+### Previous Design
+
+```rust
+let uri2 = Uri::builder()
+    .scheme(uri.scheme().unwrap().clone())                       // panics: no scheme
+    .authority(uri.authority().unwrap().clone())                 // panics: no authority
+    .path_and_query(req.uri().path_and_query().unwrap().clone()) // panics: no path
+    .build()
+    .unwrap();                                                   // panics: invalid uri
+```
+
+### New Design
+
+The base URI's scheme and authority are precomputed **once** in `RequestSender::new`,
+which stays infallible (it must, to keep the constructors returning `Self`):
+
+```rust
+let base_scheme = uri.scheme().cloned();       // Option<Scheme>
+let base_authority = uri.authority().cloned(); // Option<Authority>
+```
+
+`call` then surfaces every boundary condition as a clean per-request error future
+(mirroring the MF-2 `connect_error` deferral pattern) instead of panicking:
+
+- Missing base scheme or authority → per-request error future, returned **before** the
+  cached sender is cloned (an invalid base never consumes a connection).
+- Missing request path-and-query → defaults to origin-form `"/"`
+  (`PathAndQuery::from_static("/")`). This is the correct HTTP/3 request target for an
+  authority-form request URI (e.g. `localhost:443`, whose `path_and_query()` is `None`);
+  the `:path` pseudo-header must be a non-empty path, and `/` is the origin-form default.
+- `Uri::builder().build()` failure → per-request error future rather than `.unwrap()`.
+
+Net effect: no reachable `panic!`/`unwrap`/`expect` on user-influenced URI values in the
+request path. `Scheme`/`Authority`/`PathAndQuery` come from `hyper::http::uri` (hyper
+re-exports the `http` crate), so no new dependency is added.
+
+## SF-3: Reconnect after a peer GOAWAY
+
+When the peer sends GOAWAY, h3 0.0.8 marks the connection closing but the client **driver
+task keeps running** (its `poll_close` stays pending) to service in-flight streams — so
+the existing driver-ended reconnect path (`driver_rx` firing) never triggers. Meanwhile
+`h3::client::SendRequest::send_request` calls `check_peer_connection_closing()` and returns
+`StreamError::RemoteClosing` for any **new** request. The result: `RequestSender::call`
+kept cloning the same closing cached sender and every subsequent RPC failed permanently,
+even though a fresh connection would succeed.
+
+### Fix: a per-generation closing signal
+
+`RequestSender` gains a `closing: Arc<AtomicBool>` field. The per-request future
+(`send_request_inner`) captures a clone of the *current* flag and sets it when it observes
+a **connection-level** closing/closed error (at the `send_request` and `recv_response`
+sites). `poll_ready` checks the flag — alongside the existing `driver_rx` check — and
+retires the cached sender when it is set, so the next request reconnects:
+
+```rust
+if self.closing.load(Ordering::SeqCst) {
+    // driver stayed alive, but the peer is going away: retire and reconnect.
+    self.retire_connection();
+}
+```
+
+The request that observes the closing error fails cleanly; the **next** `poll_ready`
+reconnects (no in-place retry — consistent with the MF-2 per-request-error model). The
+first post-GOAWAY request failing, then the next reconnecting, is the intended behavior.
+
+#### Generation tagging (race safety)
+
+The `closing` flag's `Arc` identity is a **connection generation tag**. All retire paths go
+through one helper:
+
+```rust
+fn retire_connection(&mut self) {
+    self.send_request = None;
+    self.driver_rx = None;
+    self.closing = Arc::new(AtomicBool::new(false)); // fresh generation
+}
+```
+
+Installing a *fresh* `Arc` on every retire (both the driver-ended and closing-flag paths)
+is essential: an in-flight request from the retired connection still holds the previous
+`Arc`, so its late error sets the old flag and cannot invalidate the healthy new sender a
+subsequent `poll_ready` establishes. `call` clones `self.closing` at call time, so requests
+on the new connection observe the new generation.
+
+#### Connection-level vs. per-stream classification
+
+Only **connection-level** conditions retire the shared cached sender — it multiplexes
+other concurrent requests, so tearing it down on an ordinary per-stream error would
+needlessly kill healthy connections. The classifier is conservative:
+
+```rust
+fn is_connection_closing(err: &h3::error::StreamError) -> bool {
+    let msg = err.to_string();
+    msg.starts_with("Remote is closing the connection") // RemoteClosing (GOAWAY)
+        || msg.starts_with("Connection error:")         // ConnectionError(_)
+}
+```
+
+Detection goes through `Display` deliberately. In h3 0.0.8 each `StreamError` variant is
+individually `#[non_exhaustive]`, so downstream crates **cannot** name `RemoteClosing` or
+`ConnectionError(_)` in a pattern (they are reported as private — E0603), and there is no
+public predicate for the closing/GOAWAY case (`is_h3_no_error()` returns `false` for
+`RemoteClosing`). The `Display` strings are the only stable public surface distinguishing
+connection-level from stream-level errors, and `h3` is pinned to `0.0.8` in `Cargo.lock`,
+so those strings are fixed. Stream-level variants render with other prefixes ("Stream
+error:", "Remote reset:", "Header too big:", "Undefined error:") and return `false`.
+
+## Tests
+
+- `tonic-h3-tests/src/uri_boundary.rs` (SF-1) — asserts no panic for boundary URIs, each
+  yielding a clean error or the documented `/` default: a base URI missing a scheme, a
+  base URI missing an authority, and a request URI with no path-and-query.
+- `tonic-h3-tests/src/goaway_reconnect.rs` (SF-3) — a real quinn + h3 server (a fake
+  `SendRequest` cannot be injected) sends a genuine GOAWAY via
+  `h3::server::Connection::shutdown(0)` and **keeps the connection/driver alive** so the
+  client's `driver_rx` stays pending, exercising the new closing-flag path rather than the
+  pre-existing driver-ended path. A connect-counting connector proves recovery:
+  - `quinn_goaway_triggers_reconnect` — request #1 succeeds; a bounded probe loop then sees
+    a request fail cleanly with the closing error and a subsequent request succeed via
+    reconnection, with the connect count reaching **2**.
+  - `quinn_stream_error_does_not_reconnect` — a stream-level reset must NOT retire the
+    sender: the connect count stays **1** and a later request succeeds on the same
+    connection (FR-006).
+
+The existing `reconnect`, `cert_error`, `failover`, `buffered_reconnect`, `cancel_reset`,
+and `mix` suites remain green and unweakened.
+
+## Files Changed
+
+| File | Changes |
+|---|---|
+| `h3-util/src/client_conn.rs` | SF-1: precompute base scheme/authority in `new`; `call` surfaces missing/invalid URI components as per-request errors and defaults missing path to `/`. SF-3: `closing` generation flag set by `send_request_inner` on connection-level errors and observed by `poll_ready`; `retire_connection` helper installs a fresh flag on every retire; `is_connection_closing` Display-based classifier. |
+| `tonic-h3-tests/src/uri_boundary.rs` | New SF-1 boundary-URI no-panic tests. |
+| `tonic-h3-tests/src/goaway_reconnect.rs` | New SF-3 GOAWAY-reconnect and per-stream-retention tests. |
+| `tonic-h3-tests/src/lib.rs` | Register the new `uri_boundary` and `goaway_reconnect` modules. |
+| `tonic-h3-tests/Cargo.toml` | Add `h3` dependency (server-side test harness). |

--- a/docs/client-uri-goaway-fixes.md
+++ b/docs/client-uri-goaway-fixes.md
@@ -40,7 +40,7 @@ let base_authority = uri.authority().cloned(); // Option<Authority>
 (mirroring the MF-2 `connect_error` deferral pattern) instead of panicking:
 
 - Missing base scheme or authority → per-request error future, returned **before** the
-  cached sender is cloned (an invalid base never consumes a connection).
+  cached sender is cloned or used (so no request is sent on an invalid base URI).
 - Missing request path-and-query → defaults to origin-form `"/"`
   (`PathAndQuery::from_static("/")`). This is the correct HTTP/3 request target for an
   authority-form request URI (e.g. `localhost:443`, whose `path_and_query()` is `None`);

--- a/docs/deferred/README.md
+++ b/docs/deferred/README.md
@@ -1,0 +1,106 @@
+# Deferred items
+
+This document tracks review findings that were **intentionally not addressed**
+in the deep-review fix cycle, along with the rationale for deferral. It is the
+backlog companion to the completed fixes documented elsewhere in `docs/`.
+
+The findings originate from the Society-of-Thought deep review of the workspace
+crates (`tonic-h3`, `axum-h3`, `h3-util`). Each entry records what the finding
+is, why it was deferred, and what a future fix would entail.
+
+## Status of the must-fix (MF) items
+
+| Item | Summary | Status |
+|------|---------|--------|
+| MF-1 | Quinn address failover aborts on first async handshake failure | ✅ Fixed (PR #31) |
+| MF-2 | Transient connect/DNS failure permanently bricks buffered `H3Channel` | ✅ Fixed (PR #31) |
+| MF-3 | Interrupted body-send appears as graceful FIN instead of an HTTP/3 reset | ✅ Fixed (PR #32) |
+| MF-4 | Server spawns handshake/connection/request tasks without explicit caps | ⏸️ Deferred — see below |
+
+---
+
+## MF-4 — Unbounded server task spawning (reclassified: not a distinctive defect)
+
+**Where:** `h3-util/src/quinn/server.rs` (handshake `JoinSet`), `axum-h3/src/lib.rs`
+(per-connection and per-request `executor.execute`), `h3-util/src/executor.rs`
+(`SharedExec::execute` returns no handle).
+
+**Original concern:** Each incoming QUIC handshake, accepted connection, and
+HTTP/3 request stream is spawned without semaphores, retained handles, queue
+limits, or backpressure — framed by the security specialist as a
+memory-exhaustion DoS lever.
+
+**Why deferred (parity analysis):** When benchmarked against the reference
+`tonic`-over-HTTP/2 (`hyper`/`h2`) stack, this is **not a distinctive defect**:
+
+- **Per-connection request concurrency is already bounded by the QUIC
+  transport.** Quinn's default `TransportConfig` sets
+  `max_concurrent_bidi_streams = 100`
+  (`quinn-proto/src/config/transport.rs`), advertised to the peer as the QUIC
+  `initial_max_streams_bidi` transport parameter. A peer therefore cannot hold
+  more than ~100 concurrent request streams per connection, and credit is
+  returned as each request completes. This is the direct analogue of HTTP/2's
+  `SETTINGS_MAX_CONCURRENT_STREAMS` (hyper's default is 200). The per-request
+  task loop is thus **not** truly unbounded.
+- **Connection-accept is unbounded in both stacks.** `tonic`/`hyper` also spawn
+  one task per accepted connection in an unbounded accept loop. Connection-level
+  DoS is conventionally mitigated at deployment (load balancer, `ulimit`, OS
+  accept backlog) and by Quinn's own address-validation / retry-token machinery
+  and `incoming_buffer_size_total` limit — not by the application transport
+  crate.
+
+**Conclusion:** Reclassified from "must-fix DoS" to **optional future
+enhancement**. Matching the ecosystem baseline is acceptable for the current
+production (`quinn`) posture.
+
+**If revisited, a proper fix would be a *feature*, not a bug fix:**
+- Expose configurable limits: max concurrent connections, max in-flight
+  handshakes, and (optionally) max in-flight requests below the transport cap.
+- Provide shedding/backpressure semantics (reject or queue with a bound) rather
+  than unbounded spawning, comparable to `tower`'s `concurrency_limit` /
+  `load_shed` layers.
+- Retain task handles so limits and graceful shutdown (see SF-2) can coordinate.
+
+---
+
+## Other open findings from the deep review (not yet scheduled)
+
+These are lower-severity findings surfaced by the review that remain open. Full
+evidence and file:line references live in the review synthesis artifact
+(`.paw/reviews/crates-deep-review/REVIEW-SYNTHESIS.md`, not committed).
+
+### Should-fix
+
+| ID | Summary | Notes |
+|----|---------|-------|
+| SF-1 | `RequestSender::call` can panic on URIs missing scheme/authority/path | Validate the base URI in the channel constructor; return a typed error instead of `unwrap()` in the hot path. |
+| SF-2 | `serve_with_shutdown` stops accepting but does not drain in-flight work | Decide stop-only vs graceful-drain semantics; if graceful, retain task handles + drain with a timeout. Couples with MF-4. |
+| SF-3 | A peer `GOAWAY` can pin the client to a sender that rejects new requests | Retire the cached `send_request` when it reports `RemoteClosing` at call time, not only when the driver task ends. |
+| SF-4 | Opaque `Box<dyn Error>` prevents gRPC status mapping and selective retry | Introduce a non-exhaustive transport error enum preserving the source; own a `tonic::Status` mapping policy. |
+| SF-5 | The generic HTTP/3 server driver lives behind the axum adapter | Consider moving the framework-neutral connection/request loop into `h3-util`, keeping axum/tonic as thin adapters. |
+| SF-6 | Destination identity is split across connector URI, channel URI, and TLS name | A validated endpoint/target type with derived defaults would prevent accidental mismatches. |
+| SF-7 | Trace logs can expose sensitive request headers and trailers | Redact sensitive gRPC metadata (e.g. `authorization`) or log only header names. |
+| SF-8 | The client `Buffer` is fixed at 1024 entries with no public sizing control | Expose a builder/constructor option and document backpressure/sizing guidance. |
+
+### Consider
+
+| ID | Summary |
+|----|---------|
+| C-1 | Client/server incoming-body and send-body types duplicate near-identical frame state machines (do after any body-semantic changes). |
+| C-2 | Body send loops keep polling after trailers; a malformed `Body` could write an invalid frame sequence. Track a `trailers_sent` state. |
+| C-3 | Reconnect state is encoded as coupled `Option` fields; an explicit state enum + fake-connector tests would improve testability. |
+| C-4 | `H3Router` stores a `SharedExec` but `new` always uses Tokio and offers no `with_executor`. Expose it or document Tokio-only. |
+| C-5 | Backend features don't separate client vs server capability, so client-only users compile the axum server stack. |
+| C-6 | `H3Connector`/`H3Acceptor` require implementers to repeat stream associated types already fixed by the connection type. |
+| C-7 | The unary client path allocates a cancellation channel and boxes futures before knowing whether a background body task is needed. |
+| C-8 | Stale commented-out code / TODOs and typoed trace strings (`incomming`) obscure intent. |
+
+---
+
+## Provenance
+
+Deferral decisions were made during an evaluate-then-fix cycle in which each
+must-fix finding was verified against real dependency source
+(`tower`, `quinn`/`quinn-proto`, `h3`). MF-1/MF-2/MF-3 were fixed; MF-4 was
+reclassified as above. The should-fix and consider items were not in scope for
+that cycle and are recorded here so they are not lost.

--- a/h3-util/src/client_conn.rs
+++ b/h3-util/src/client_conn.rs
@@ -7,13 +7,46 @@ use hyper::{
     rt::Executor,
 };
 use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::client_body::H3IncomingClient;
+
+/// SF-3: classify an h3 stream error as a *connection-level* closing/closed condition
+/// (as opposed to an ordinary single-stream error). Only connection-level conditions
+/// should retire the shared cached `SendRequest`, because that sender multiplexes other
+/// concurrent requests on the same connection; tearing it down on an ordinary per-stream
+/// error would needlessly kill healthy connections (SF-3, FR-006).
+///
+/// In h3 0.0.8 a peer GOAWAY makes `SendRequest::send_request` reject any *new* request
+/// with `StreamError::RemoteClosing` — the driver task may keep running for in-flight
+/// streams, so the driver-ended reconnect path does not fire. `ConnectionError(_)`
+/// likewise means the whole connection is gone. Every other `StreamError` variant is
+/// stream-scoped and must NOT invalidate the shared sender.
+///
+/// Detection has to go through `Display`: in h3 0.0.8 each `StreamError` variant is
+/// individually `#[non_exhaustive]`, so downstream crates cannot name `RemoteClosing`
+/// or `ConnectionError(_)` in a pattern (they are treated as private — E0603), and no
+/// public predicate exists for the closing/GOAWAY case (`is_h3_no_error()` returns
+/// `false` for `RemoteClosing`). The `Display` strings are the only stable public
+/// surface distinguishing connection-level from stream-level errors; `h3` is pinned to
+/// `0.0.8` in `Cargo.lock`, so these strings are fixed. The connection-level prefixes are
+/// `RemoteClosing` => "Remote is closing the connection" and
+/// `ConnectionError(_)` => "Connection error: ..."; all other variants render as
+/// "Stream error:", "Remote reset:", "Header too big:", or "Undefined error:".
+fn is_connection_closing(err: &h3::error::StreamError) -> bool {
+    let msg = err.to_string();
+    msg.starts_with("Remote is closing the connection") || msg.starts_with("Connection error:")
+}
 
 pub async fn send_request_inner<CONN, B>(
     req: hyper::Request<B>,
     mut send_request: h3::client::SendRequest<CONN::OS, Bytes>,
     executor: &SharedExec,
+    // SF-3: set to `true` when a connection-level closing/closed condition is observed,
+    // so `RequestSender::poll_ready` retires the cached sender and reconnects. This is the
+    // generation flag captured when the owning request was created (see `call`).
+    closing: Arc<AtomicBool>,
 ) -> Result<Response<H3IncomingClient<CONN::RS, Bytes>>, crate::Error>
 where
     CONN: H3Connector,
@@ -27,7 +60,17 @@ where
     tracing::trace!("sending h3 req header: {:?}", head_req);
 
     // send header.
-    let stream = send_request.send_request(head_req).await?;
+    let stream = match send_request.send_request(head_req).await {
+        Ok(stream) => stream,
+        Err(e) => {
+            // SF-3: a new request rejected because the peer connection is closing
+            // (GOAWAY) must retire the cached sender so the next request reconnects.
+            if is_connection_closing(&e) {
+                closing.store(true, Ordering::SeqCst);
+            }
+            return Err(e.into());
+        }
+    };
 
     let (w, mut r) = stream.split();
 
@@ -63,13 +106,19 @@ where
 
     // return resp.
     tracing::trace!("recv header");
-    let (resp, _) = r
-        .recv_response()
-        .await
-        .inspect_err(|e| {
+    let resp = match r.recv_response().await {
+        Ok(resp) => resp,
+        Err(e) => {
             tracing::error!("recv header error: {e}");
-        })?
-        .into_parts();
+            // SF-3: a connection-level closing/closed error while awaiting the response
+            // also warrants retiring the cached sender so the next request reconnects.
+            if is_connection_closing(&e) {
+                closing.store(true, Ordering::SeqCst);
+            }
+            return Err(e.into());
+        }
+    };
+    let (resp, _) = resp.into_parts();
     let resp_body = H3IncomingClient::new(r, Some(cancel_tx));
     tracing::trace!("return resp");
     Ok(hyper::Response::from_parts(resp, resp_body))
@@ -107,6 +156,15 @@ pub struct RequestSender<CONN: H3Connector> {
     // as permanently failed (it closes the request channel and replays the stored error
     // to every subsequent request and cloned handle), which would defeat reconnection.
     connect_error: Option<crate::Error>,
+    // SF-3: shared "connection is closing" signal for the CURRENT connection generation.
+    // A peer GOAWAY marks the connection closing while the driver task may keep running
+    // for in-flight streams (so `driver_rx` never fires). The per-request future sets this
+    // flag when `send_request`/`recv_response` reports a connection-level closing/closed
+    // condition; `poll_ready` observes it and retires the cached sender so the next connect
+    // reconnects. Its `Arc` identity is the generation tag: on retire/reconnect a FRESH
+    // flag is installed, so a late error from a retired connection (which still holds the
+    // old `Arc`) cannot invalidate the new healthy sender.
+    closing: Arc<AtomicBool>,
 }
 
 impl<CONN> RequestSender<CONN>
@@ -129,7 +187,20 @@ where
             base_scheme,
             base_authority,
             connect_error: None,
+            closing: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Retire the current connection generation: drop the cached sender and its driver
+    /// signal, and install a FRESH `closing` flag. Installing a fresh `Arc` is essential
+    /// for the SF-3 generation-tagging: an in-flight request from the retired connection
+    /// still holds the previous `Arc`, so setting it must not invalidate the healthy new
+    /// sender a subsequent `poll_ready` establishes. All retire paths (driver-ended and
+    /// connection-closing) go through here so no path leaks a stale generation flag.
+    fn retire_connection(&mut self) {
+        self.send_request = None;
+        self.driver_rx = None;
+        self.closing = Arc::new(AtomicBool::new(false));
     }
 }
 
@@ -154,18 +225,30 @@ where
             match rx.try_recv() {
                 Ok(()) => {
                     tracing::trace!("driver is closed, reconnecting.");
-                    self.send_request = None;
-                    self.driver_rx = None;
+                    self.retire_connection();
                 }
                 Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
                     // driver is still running
                 }
                 Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
                     tracing::trace!("driver is closed, reconnecting.");
-                    self.send_request = None;
-                    self.driver_rx = None;
+                    self.retire_connection();
                 }
             }
+        }
+
+        // SF-3: a peer GOAWAY marks the connection closing while the driver task may keep
+        // running for in-flight streams (so the `driver_rx` check above does NOT fire). A
+        // per-request future sets `closing` when it observes a connection-level closing/
+        // closed error; retire the cached sender here so the next connect reconnects.
+        // `retire_connection` installs a FRESH generation flag so an in-flight request from
+        // the retired connection (still holding the previous `Arc`) cannot invalidate the
+        // new healthy sender. `tower::Buffer` serializes `poll_ready`->`call` and this runs
+        // on every readiness poll, so a set flag is observed before the next `call` clones
+        // the sender; a missed poll self-corrects on the following request.
+        if self.closing.load(Ordering::SeqCst) {
+            tracing::trace!("connection is closing (goaway), reconnecting.");
+            self.retire_connection();
         }
 
         // Idempotency guard (tower `Service` contract): if a previous connect attempt
@@ -289,8 +372,14 @@ where
 
         *req.uri_mut() = uri2;
         let executor = self.executor.clone();
+        // SF-3: capture the CURRENT connection generation's closing flag. If this request
+        // observes a connection-closing error, it sets this flag; the next `poll_ready`
+        // retires the sender and reconnects. Cloning the current `Arc` (rather than a
+        // fixed one) is what makes generation-tagging work.
+        let closing = self.closing.clone();
         Box::pin(async move {
-            crate::client_conn::send_request_inner::<CONN, B>(req, send_request, &executor).await
+            crate::client_conn::send_request_inner::<CONN, B>(req, send_request, &executor, closing)
+                .await
         })
     }
 }

--- a/h3-util/src/client_conn.rs
+++ b/h3-util/src/client_conn.rs
@@ -3,6 +3,7 @@ use futures::{FutureExt, future::BoxFuture};
 use hyper::{
     Request, Response, Uri,
     body::{Body, Bytes},
+    http::uri::{Authority, PathAndQuery, Scheme},
     rt::Executor,
 };
 use std::future::Future;
@@ -92,8 +93,14 @@ pub struct RequestSender<CONN: H3Connector> {
             >,
         >,
     >,
-    uri: Uri,
     executor: SharedExec,
+    // Precomputed base URI parts (SF-1). The public constructors accept any `http::Uri`,
+    // whose scheme and authority are `Option`s. We validate/clone them once here so the
+    // request hot path (`call`) never unwraps a user-supplied `Option` and panics. `None`
+    // records that the base URI lacked that component; `call` surfaces this as a
+    // per-request error future rather than panicking (mirroring `connect_error`).
+    base_scheme: Option<Scheme>,
+    base_authority: Option<Authority>,
     // Stores a connect/handshake error from `poll_ready` so it can be surfaced as a
     // per-request failure from `call` instead of a terminal readiness error. Returning
     // an error from `poll_ready` would cause `tower::buffer::Buffer` to treat the channel
@@ -107,13 +114,20 @@ where
     CONN: H3Connector,
 {
     pub fn new(conn: CONN, uri: Uri, executor: SharedExec) -> Self {
+        // SF-1: precompute/validate the base URI's scheme and authority once. Do NOT
+        // panic here on a missing component — the public constructors must stay
+        // infallible (return `Self`). Absence is recorded and surfaced per-request
+        // from `call` as a clean error future.
+        let base_scheme = uri.scheme().cloned();
+        let base_authority = uri.authority().cloned();
         Self {
             conn,
             send_request: None,
             driver_rx: None,
             make_send_request_fut: None,
-            uri,
             executor,
+            base_scheme,
+            base_authority,
             connect_error: None,
         }
     }
@@ -220,6 +234,44 @@ where
             return Box::pin(async move { Err(e) });
         }
 
+        // SF-1: rebuild the request URI from the validated base scheme+authority and the
+        // request's path-and-query, surfacing any missing/invalid component as a
+        // per-request error future (mirroring the `connect_error` shape) instead of
+        // panicking. Done BEFORE cloning the cached sender so an invalid base URI never
+        // consumes a connection.
+        let (scheme, authority) = match (self.base_scheme.clone(), self.base_authority.clone()) {
+            (Some(scheme), Some(authority)) => (scheme, authority),
+            (None, _) => {
+                return Box::pin(async move {
+                    Err(crate::Error::from("h3 client base URI is missing a scheme"))
+                });
+            }
+            (_, None) => {
+                return Box::pin(async move {
+                    Err(crate::Error::from(
+                        "h3 client base URI is missing an authority",
+                    ))
+                });
+            }
+        };
+        // A request target without a path-and-query defaults to origin-form "/".
+        let path_and_query = req
+            .uri()
+            .path_and_query()
+            .cloned()
+            .unwrap_or_else(|| PathAndQuery::from_static("/"));
+        let uri2 = match Uri::builder()
+            .scheme(scheme)
+            .authority(authority)
+            .path_and_query(path_and_query)
+            .build()
+        {
+            Ok(uri2) => uri2,
+            Err(e) => {
+                return Box::pin(async move { Err(crate::Error::from(e)) });
+            }
+        };
+
         // Defensive: under the tower `Service` contract `call` is only reached after a
         // `poll_ready` that returned `Ready(Ok)`, which means either a cached sender or a
         // pending connect error existed. If neither holds (contract violation), return an
@@ -235,15 +287,6 @@ where
             }
         };
 
-        // replace the uri
-        let uri = &self.uri;
-        // fix up uri with full uri.
-        let uri2 = Uri::builder()
-            .scheme(uri.scheme().unwrap().clone())
-            .authority(uri.authority().unwrap().clone())
-            .path_and_query(req.uri().path_and_query().unwrap().clone())
-            .build()
-            .unwrap();
         *req.uri_mut() = uri2;
         let executor = self.executor.clone();
         Box::pin(async move {

--- a/tonic-h3-tests/Cargo.toml
+++ b/tonic-h3-tests/Cargo.toml
@@ -18,6 +18,7 @@ tonic-prost.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 h3-util.workspace = true
+h3.workspace = true
 axum.workspace = true
 axum-h3.workspace = true
 http-body-util.workspace = true

--- a/tonic-h3-tests/src/goaway_reconnect.rs
+++ b/tonic-h3-tests/src/goaway_reconnect.rs
@@ -1,0 +1,339 @@
+//! Regression tests for SF-3: a peer GOAWAY must NOT pin the client to a cached
+//! `SendRequest` that rejects every subsequent request forever.
+//!
+//! In h3 0.0.8, when the peer sends GOAWAY the connection is marked closing while the
+//! client driver task can keep running (its `poll_close` stays pending) to service
+//! in-flight streams. So the existing driver-ended reconnect path (`driver_rx`) does NOT
+//! fire, yet `SendRequest::send_request` returns `StreamError::RemoteClosing` for every
+//! NEW request. The fix makes the per-request future flag a connection-level closing
+//! condition so `poll_ready` retires the cached sender and the next request reconnects.
+//!
+//! These tests drive a real quinn + h3 server (a fake `SendRequest` cannot be injected —
+//! it is a concrete type produced by `h3::client::new`). The server sends a genuine
+//! GOAWAY via `h3::server::Connection::shutdown(0)` and then keeps the connection/driver
+//! alive, reproducing the exact SF-3 condition (driver stays alive, `driver_rx` pending).
+//!
+//! A connect-counting connector (mirroring `FailOnce` in `buffered_reconnect.rs`) lets the
+//! tests assert whether the client actually reconnected (connect count) rather than
+//! merely "eventually succeeded".
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use h3_util::client::H3Connector;
+use h3_util::quinn::h3_quinn;
+use http::{Request, Uri};
+use hyper::body::Bytes;
+use tokio_util::sync::CancellationToken;
+
+/// An `H3Connector` wrapper that counts how many times `connect()` is invoked, delegating
+/// every call to the inner (real) connector. The shared counter lets a test assert that a
+/// reconnect actually happened (count == 2) — or did NOT happen (count stays 1).
+#[derive(Clone)]
+struct CountConnect<C: H3Connector> {
+    inner: C,
+    count: Arc<AtomicUsize>,
+}
+
+impl<C: H3Connector> CountConnect<C> {
+    fn new(inner: C) -> (Self, Arc<AtomicUsize>) {
+        let count = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                inner,
+                count: count.clone(),
+            },
+            count,
+        )
+    }
+}
+
+impl<C: H3Connector> H3Connector for CountConnect<C> {
+    type CONN = C::CONN;
+    type OS = C::OS;
+    type SS = C::SS;
+    type RS = C::RS;
+    type BS = C::BS;
+
+    fn connect(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Self::CONN, h3_util::Error>> + Send {
+        // Own the clones so the returned future is `Send` and does not borrow `&self`.
+        let inner = self.inner.clone();
+        let count = self.count.clone();
+        async move {
+            count.fetch_add(1, Ordering::SeqCst);
+            inner.connect().await
+        }
+    }
+}
+
+type ServerConn = h3::server::Connection<h3_quinn::Connection, Bytes>;
+
+/// Accept a single request on `conn` and answer it with an empty `200` response.
+/// Returns `true` if a request was served, `false` if the connection ended.
+async fn serve_one_ok(conn: &mut ServerConn) -> bool {
+    match conn.accept().await {
+        Ok(Some(resolver)) => match resolver.resolve_request().await {
+            Ok((_req, mut stream)) => {
+                let resp = http::Response::builder().status(200).body(()).unwrap();
+                if stream.send_response(resp).await.is_err() {
+                    return true;
+                }
+                let _ = stream.finish().await;
+                true
+            }
+            Err(_) => true,
+        },
+        Ok(None) | Err(_) => false,
+    }
+}
+
+/// Serve requests normally until the connection ends or the token is cancelled.
+async fn serve_forever(conn: &mut ServerConn, token: &CancellationToken) {
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => break,
+            served = serve_one_ok(conn) => {
+                if !served {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Spawn a quinn + h3 server whose FIRST connection serves exactly one request, then sends
+/// GOAWAY (`shutdown(0)`) and keeps the connection alive so the client driver's
+/// `poll_close` stays pending. Every subsequent connection (the reconnect) is served
+/// normally. Returns the accept-loop join handle.
+fn run_goaway_server(
+    endpoint: h3_quinn::quinn::Endpoint,
+    token: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut idx = 0usize;
+        loop {
+            let incoming = tokio::select! {
+                _ = token.cancelled() => break,
+                inc = endpoint.accept() => match inc {
+                    Some(i) => i,
+                    None => break,
+                },
+            };
+            idx += 1;
+            let is_first = idx == 1;
+            let token = token.clone();
+            tokio::spawn(async move {
+                let quinn_conn = match incoming.await {
+                    Ok(c) => c,
+                    Err(_) => return,
+                };
+                let h3_conn = h3_quinn::Connection::new(quinn_conn);
+                let mut conn = match ServerConn::new(h3_conn).await {
+                    Ok(c) => c,
+                    Err(_) => return,
+                };
+                if is_first {
+                    // Serve exactly one request, then send GOAWAY and hold the connection
+                    // open so the client driver stays alive (driver_rx must NOT fire).
+                    let _ = serve_one_ok(&mut conn).await;
+                    let _ = conn.shutdown(0).await;
+                    token.cancelled().await;
+                } else {
+                    // The reconnect: serve normally.
+                    serve_forever(&mut conn, &token).await;
+                }
+            });
+        }
+    })
+}
+
+fn empty_post(uri: &Uri) -> Request<http_body_util::Empty<Bytes>> {
+    Request::builder()
+        .method("POST")
+        .uri(uri.clone())
+        .body(http_body_util::Empty::<Bytes>::new())
+        .unwrap()
+}
+
+/// SF-3 core: after a peer GOAWAY (driver kept alive), the client retires the cached
+/// sender and reconnects instead of failing every request forever.
+#[tokio::test]
+#[test_log::test]
+async fn quinn_goaway_triggers_reconnect() {
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let endpoint = crate::make_quinn_server_endpoint(addr);
+    let listen_addr = endpoint.local_addr().unwrap();
+    let token = CancellationToken::new();
+    let h_svr = run_goaway_server(endpoint, token.clone());
+
+    let uri: Uri = format!("https://localhost:{}", listen_addr.port())
+        .parse()
+        .unwrap();
+    let client_endpoint = crate::make_test_quinn_client_endpoint();
+    let real = tonic_h3::quinn::H3QuinnConnector::new(
+        uri.clone(),
+        "localhost".to_string(),
+        client_endpoint.clone(),
+    );
+    let (cc, connect_count) = CountConnect::new(real);
+    let channel = h3_util::client::H3Connection::new(cc, uri.clone(), None);
+    let mut client = h3_util::client::H3Client::new(channel);
+
+    // Request #1 succeeds on connection 1.
+    client
+        .send(empty_post(&uri))
+        .await
+        .expect("first request should succeed on connection 1");
+    assert_eq!(
+        connect_count.load(Ordering::SeqCst),
+        1,
+        "exactly one connect for the first request"
+    );
+
+    // Give the GOAWAY time to reach and be processed by the client driver. The bounded
+    // probe loop below is the deterministic backstop: it retries until the client has
+    // observed the closing condition and reconnected.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let mut saw_closing_failure = false;
+    let mut reconnected = false;
+    for attempt in 0..20 {
+        let res = tokio::time::timeout(Duration::from_secs(3), client.send(empty_post(&uri))).await;
+        match res {
+            Ok(Ok(_resp)) => {
+                // Recovered via reconnection.
+                reconnected = true;
+                break;
+            }
+            Ok(Err(e)) => {
+                let msg = e.to_string();
+                tracing::debug!("probe attempt {attempt} failed (expected once): {msg}");
+                // The first post-GOAWAY request must fail cleanly with the closing signal
+                // (RemoteClosing -> "Remote is closing the connection"), never a panic.
+                if msg.contains("closing") {
+                    saw_closing_failure = true;
+                }
+            }
+            Err(_timeout) => {
+                tracing::debug!("probe attempt {attempt} timed out; retrying");
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
+    assert!(
+        saw_closing_failure,
+        "expected at least one post-GOAWAY request to fail with a connection-closing error"
+    );
+    assert!(
+        reconnected,
+        "expected a subsequent request to succeed via reconnection after GOAWAY"
+    );
+    assert_eq!(
+        connect_count.load(Ordering::SeqCst),
+        2,
+        "the client must have established a second connection (reconnect), not reused the closing one"
+    );
+
+    // Cleanup.
+    client_endpoint.close(0_u16.into(), b"client close");
+    token.cancel();
+    let _ = h_svr.await;
+}
+
+/// Spawn a server for a SINGLE connection whose first request stream is reset at the
+/// stream level (no GOAWAY), and whose subsequent requests are served normally. This
+/// exercises the FR-006 guarantee that an ordinary per-stream error must NOT retire the
+/// shared cached sender.
+fn run_stream_reset_server(
+    endpoint: h3_quinn::quinn::Endpoint,
+    token: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let incoming = tokio::select! {
+            _ = token.cancelled() => return,
+            inc = endpoint.accept() => match inc {
+                Some(i) => i,
+                None => return,
+            },
+        };
+        let quinn_conn = match incoming.await {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+        let h3_conn = h3_quinn::Connection::new(quinn_conn);
+        let mut conn = match ServerConn::new(h3_conn).await {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        // First request: reset the stream (stream-level error, connection stays healthy).
+        if let Ok(Some(resolver)) = conn.accept().await
+            && let Ok((_req, mut stream)) = resolver.resolve_request().await
+        {
+            stream.stop_stream(h3::error::Code::H3_INTERNAL_ERROR);
+            // Drop the stream without sending a response -> client sees a stream error.
+        }
+
+        // Subsequent requests on the SAME connection are served normally.
+        serve_forever(&mut conn, &token).await;
+    })
+}
+
+/// FR-006 / SC-003: an ordinary per-stream error must NOT invalidate the shared cached
+/// sender. The connect count must stay at 1 (no reconnect) and a subsequent request must
+/// succeed on the SAME connection.
+#[tokio::test]
+#[test_log::test]
+async fn quinn_stream_error_does_not_reconnect() {
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let endpoint = crate::make_quinn_server_endpoint(addr);
+    let listen_addr = endpoint.local_addr().unwrap();
+    let token = CancellationToken::new();
+    let h_svr = run_stream_reset_server(endpoint, token.clone());
+
+    let uri: Uri = format!("https://localhost:{}", listen_addr.port())
+        .parse()
+        .unwrap();
+    let client_endpoint = crate::make_test_quinn_client_endpoint();
+    let real = tonic_h3::quinn::H3QuinnConnector::new(
+        uri.clone(),
+        "localhost".to_string(),
+        client_endpoint.clone(),
+    );
+    let (cc, connect_count) = CountConnect::new(real);
+    let channel = h3_util::client::H3Connection::new(cc, uri.clone(), None);
+    let mut client = h3_util::client::H3Client::new(channel);
+
+    // Request #1: the server resets the stream -> a per-stream error surfaces.
+    let first = tokio::time::timeout(Duration::from_secs(5), client.send(empty_post(&uri))).await;
+    assert!(
+        matches!(first, Ok(Err(_))),
+        "expected the first request to fail with a stream-level error (Ok(Err), got timeout or success)"
+    );
+    assert_eq!(
+        connect_count.load(Ordering::SeqCst),
+        1,
+        "a stream-level error must NOT retire the sender: still exactly one connect"
+    );
+
+    // Request #2 must succeed on the SAME connection (no reconnect).
+    let second = tokio::time::timeout(Duration::from_secs(5), client.send(empty_post(&uri))).await;
+    assert!(
+        matches!(second, Ok(Ok(_))),
+        "expected a subsequent request to succeed on the same connection (got timeout or error)"
+    );
+    assert_eq!(
+        connect_count.load(Ordering::SeqCst),
+        1,
+        "no reconnect should have happened for a per-stream error (connect count stays 1)"
+    );
+
+    // Cleanup.
+    client_endpoint.close(0_u16.into(), b"client close");
+    token.cancel();
+    let _ = h_svr.await;
+}

--- a/tonic-h3-tests/src/lib.rs
+++ b/tonic-h3-tests/src/lib.rs
@@ -34,6 +34,9 @@ mod buffered_reconnect;
 #[cfg(test)]
 mod cancel_reset;
 
+#[cfg(test)]
+mod uri_boundary;
+
 pub mod cert_gen;
 
 tonic::include_proto!("helloworld"); // The string specified here must match the proto package name

--- a/tonic-h3-tests/src/lib.rs
+++ b/tonic-h3-tests/src/lib.rs
@@ -37,6 +37,9 @@ mod cancel_reset;
 #[cfg(test)]
 mod uri_boundary;
 
+#[cfg(test)]
+mod goaway_reconnect;
+
 pub mod cert_gen;
 
 tonic::include_proto!("helloworld"); // The string specified here must match the proto package name

--- a/tonic-h3-tests/src/uri_boundary.rs
+++ b/tonic-h3-tests/src/uri_boundary.rs
@@ -1,0 +1,164 @@
+//! Regression tests for SF-1: `RequestSender::call` must never panic on
+//! boundary-shaped URIs. The client constructors accept any `http::Uri`, whose
+//! `scheme`/`authority` are `Option`s, and the per-request URI's `path_and_query`
+//! is likewise optional. Previously `call` unwrapped all of these (plus the rebuilt
+//! URI), so a base URI missing scheme/authority, or a request URI missing a path,
+//! panicked deep inside the async `tower::Service::call` task.
+//!
+//! The fix precomputes/validates the base scheme+authority once in
+//! `RequestSender::new` (without panicking) and surfaces any missing/invalid
+//! component as a per-request error future, and defaults a request URI without a
+//! `path_and_query` to origin-form "/".
+//!
+//! These tests drive the raw `H3Connection` + `H3Client` path (as in
+//! `buffered_reconnect.rs` / `cancel_reset.rs`) so the test controls the base URI
+//! and the per-request URI directly. The connector always targets the real running
+//! server (so `poll_ready` reaches readiness and `call` runs the rewrite), while the
+//! boundary-shaped URI is passed as the *base* URI to `H3Connection::new`.
+
+use http::{Request, Uri};
+use tokio_util::sync::CancellationToken;
+
+type EmptyBody = http_body_util::Empty<hyper::body::Bytes>;
+
+fn empty_body() -> EmptyBody {
+    EmptyBody::new()
+}
+
+/// Build a raw non-buffered client whose connector targets `server_uri` (valid) but
+/// whose base URI is `base_uri` (possibly boundary-shaped).
+fn make_client(
+    server_uri: &Uri,
+    base_uri: Uri,
+) -> h3_util::client::H3Client<tonic_h3::quinn::H3QuinnConnector, EmptyBody> {
+    let client_endpoint = crate::make_test_quinn_client_endpoint();
+    let cc = tonic_h3::quinn::H3QuinnConnector::new(
+        server_uri.clone(),
+        "localhost".to_string(),
+        client_endpoint,
+    );
+    let conn = h3_util::client::H3Connection::new(cc, base_uri, None);
+    h3_util::client::H3Client::new(conn)
+}
+
+/// SF-1: a base URI with an authority but no scheme (e.g. `localhost:PORT`) must yield
+/// a clean per-request error rather than panicking at `scheme().unwrap()`.
+#[tokio::test]
+#[test_log::test]
+#[serial_test::serial(uri_boundary)]
+async fn quinn_base_uri_missing_scheme_no_panic() {
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let token = CancellationToken::new();
+    let (h_svr, listen_addr) = crate::run_test_quinn_hello_server(addr, token.clone());
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let server_uri: Uri = format!("https://localhost:{}", listen_addr.port())
+        .parse()
+        .unwrap();
+    // Authority present, scheme absent.
+    let base_uri: Uri = format!("localhost:{}", listen_addr.port()).parse().unwrap();
+    assert!(
+        base_uri.scheme().is_none(),
+        "test setup: base must lack scheme"
+    );
+    assert!(
+        base_uri.authority().is_some(),
+        "test setup: base should carry an authority"
+    );
+
+    let mut client = make_client(&server_uri, base_uri);
+    let req = Request::builder()
+        .method("POST")
+        .uri(&server_uri)
+        .body(empty_body())
+        .unwrap();
+    let res = client.send(req).await;
+    assert!(
+        res.is_err(),
+        "expected a clean error for a base URI missing a scheme, got Ok"
+    );
+    tracing::debug!("missing-scheme base URI error (expected): {:?}", res.err());
+
+    token.cancel();
+    h_svr.await.unwrap();
+}
+
+/// SF-1: a base URI with neither scheme nor authority (e.g. `/path`) must yield a clean
+/// per-request error rather than panicking.
+#[tokio::test]
+#[test_log::test]
+#[serial_test::serial(uri_boundary)]
+async fn quinn_base_uri_missing_authority_no_panic() {
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let token = CancellationToken::new();
+    let (h_svr, listen_addr) = crate::run_test_quinn_hello_server(addr, token.clone());
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let server_uri: Uri = format!("https://localhost:{}", listen_addr.port())
+        .parse()
+        .unwrap();
+    // Neither scheme nor authority.
+    let base_uri: Uri = "/some/path".parse().unwrap();
+    assert!(
+        base_uri.authority().is_none(),
+        "test setup: base must lack authority"
+    );
+
+    let mut client = make_client(&server_uri, base_uri);
+    let req = Request::builder()
+        .method("POST")
+        .uri(&server_uri)
+        .body(empty_body())
+        .unwrap();
+    let res = client.send(req).await;
+    assert!(
+        res.is_err(),
+        "expected a clean error for a base URI missing an authority, got Ok"
+    );
+    tracing::debug!(
+        "missing-authority base URI error (expected): {:?}",
+        res.err()
+    );
+
+    token.cancel();
+    h_svr.await.unwrap();
+}
+
+/// SF-1: a request URI with no `path_and_query` (authority-form target) must not panic;
+/// the path defaults to origin-form "/", so the request completes at the transport level.
+#[tokio::test]
+#[test_log::test]
+#[serial_test::serial(uri_boundary)]
+async fn quinn_request_uri_missing_path_defaults_to_root() {
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let token = CancellationToken::new();
+    let (h_svr, listen_addr) = crate::run_test_quinn_hello_server(addr, token.clone());
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let server_uri: Uri = format!("https://localhost:{}", listen_addr.port())
+        .parse()
+        .unwrap();
+    // Valid absolute base URI.
+    let mut client = make_client(&server_uri, server_uri.clone());
+
+    // Authority-form request target has no path_and_query.
+    let req_uri: Uri = format!("localhost:{}", listen_addr.port()).parse().unwrap();
+    assert!(
+        req_uri.path_and_query().is_none(),
+        "test setup: request URI must lack path_and_query"
+    );
+    let req = Request::builder()
+        .method("POST")
+        .uri(req_uri)
+        .body(empty_body())
+        .unwrap();
+    let res = client.send(req).await;
+    assert!(
+        res.is_ok(),
+        "expected the request to succeed with a defaulted '/' path, got {:?}",
+        res.err()
+    );
+
+    token.cancel();
+    h_svr.await.unwrap();
+}


### PR DESCRIPTION
## Summary

Two verified client-side reliability fixes from the Society-of-Thought deep review
(should-fix items SF-1 and SF-3), following the already-merged MF-1/MF-2/MF-3 work. Both
are **non-breaking** — the public constructors (`H3Channel::new`, `H3Connection::new`,
`H3Client::new`) still return `Self`; invalid input is surfaced as per-request errors,
mirroring the MF-2 `connect_error` deferral pattern.

This PR also carries a pre-existing **deferred-items backlog doc** commit
(`docs/deferred/README.md`, `56403be`) that was already on `dev`; bundling it here as a
single "review follow-ups" PR is intended.

## Changes

### SF-1 — `RequestSender::call` no longer panics on boundary URIs
The URI-rewrite block unwrapped every optional component, so a base URI missing a
scheme/authority, a request URI missing a path-and-query, or an invalid rebuilt URI
panicked deep inside `tower::Service::call`, aborting the request task.

- Base scheme + authority are precomputed once in `RequestSender::new` (kept infallible).
- `call` surfaces a missing base scheme/authority as a clean per-request error future
  **before** cloning the cached sender, defaults a missing request path-and-query to
  origin-form `/` (correct HTTP/3 `:path` target for authority-form request URIs), and
  replaces the final `.build().unwrap()` with per-request error handling.
- Net effect: no reachable `panic!`/`unwrap`/`expect` on user-influenced URI values in the
  request path.

### SF-3 — reconnect after a peer GOAWAY instead of pinning to a closing sender
In h3 0.0.8 a peer GOAWAY marks the connection closing while the client driver keeps
running (its `poll_close` stays pending) for in-flight streams, so the existing
driver-ended reconnect path (`driver_rx`) never fires — yet `SendRequest::send_request`
rejects every new request with `RemoteClosing`. The cached sender was thus permanently
bricked.

- Added a per-generation `closing: Arc<AtomicBool>` signal: the per-request future sets it
  on a **connection-level** closing/closed error; `poll_ready` observes it (alongside
  `driver_rx`) and retires the sender so the next request reconnects.
- A single `retire_connection()` helper installs a **fresh** generation `Arc` on every
  retire path, so a late error from a retired connection cannot tear down a healthy new
  sender (race-safe generation tagging).
- Only connection-level conditions invalidate the shared multiplexing sender; ordinary
  per-stream errors are retained (they multiplex other concurrent requests).
- h3 0.0.8's `StreamError` variants are individually `#[non_exhaustive]`, so
  `RemoteClosing`/`ConnectionError` cannot be pattern-matched externally and no public
  predicate exists; classification uses the stable `Display` representation of the pinned
  version (documented in `docs/client-uri-goaway-fixes.md`).

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets --features tonic-h3/quinn,h3-util/quinn`
  (no warnings), and `cargo build` all clean.
- `cargo test -p tonic-h3-test --features tonic-h3/quinn,h3-util/quinn`: **19 passed, 4
  ignored**.
- New tests:
  - `tonic-h3-tests/src/uri_boundary.rs` — SF-1 no-panic for base URI missing
    scheme/authority and request URI missing path (→ `/`).
  - `tonic-h3-tests/src/goaway_reconnect.rs` — SF-3: a real quinn+h3 server sends GOAWAY via
    `shutdown(0)` while keeping the connection/driver alive; the client recovers by
    reconnecting (connect count == 2). A per-stream reset does NOT reconnect (count stays
    1). Verified deterministic across repeated runs.
- Existing `reconnect`, `cert_error`, `failover`, `buffered_reconnect`, `cancel_reset`, and
  `mix` suites remain green and unweakened.

## Breaking Changes

None. Public constructor signatures are unchanged.

## Docs

`docs/client-uri-goaway-fixes.md` documents both fixes, the `/` default decision, the h3
0.0.8 `Display`-based classification rationale, and the generation-tagging race safety.

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)