### PR TITLE
Update quic backends (msquic-h3 0.0.7, quiche-h3 0.0.2) + quiche graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "msquic-h3"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78178d11fe6744c1df64a177673e80ca4a3f3b624731031e58674ce51ac5a76e"
+checksum = "b9559bd63fea209affcbcb1b42c8ffed590cbbb02c1edcaf6d23c54682ae1a0c"
 dependencies = [
  "bytes",
  "futures",
@@ -2333,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "quiche-h3"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685d613e272563c37905697b3bea7a8ac47f10eec229349fb6a83178d0f17474"
+checksum = "9f0a73289e282a0066258d81d90dd4d01d3bce47a1c39ac207543950ce2bb522"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 trait-variant = "0.1"
 s2n-quic = { version = "1", default-features = false, features = ["provider-tls-rustls", "provider-address-token-default"] }
-msquic-h3 = { version = "0.0.6", features = [] }
+msquic-h3 = { version = "0.0.7", features = [] }
 msquic = { version = "2.5.1-beta", default-features = false, features = ["find"] }
 
 axum = {version = "0.8", default-features = false}
@@ -37,7 +37,7 @@ http-body-util = "0.1"
 bytes = "1"
 
 # quiche-h3 bridge crate (implements the h3::quic traits over tokio-quiche)
-quiche-h3 = "0.0.1"
+quiche-h3 = "0.0.2"
 
 # crates in this workspace
 tonic-h3 = { path = "tonic-h3" }

--- a/h3-util/src/quiche_h3/server.rs
+++ b/h3-util/src/quiche_h3/server.rs
@@ -29,6 +29,18 @@ impl H3QuicheAcceptor {
         })?;
         Ok(Self { inner })
     }
+
+    /// Return a cloneable [`H3QuicheEndpoint`] handle for graceful shutdown.
+    ///
+    /// The handle shares the acceptor's endpoint registry and outlives the
+    /// acceptor, so it can drive [`close`](quiche_h3::H3QuicheEndpoint::close)
+    /// and [`wait_idle`](quiche_h3::H3QuicheEndpoint::wait_idle) even after the
+    /// acceptor has been moved into a serving task and dropped. Take it before
+    /// serving to drain live connection workers on shutdown so the UDP port can
+    /// be rebound promptly.
+    pub fn endpoint(&self) -> quiche_h3::H3QuicheEndpoint {
+        self.inner.endpoint()
+    }
 }
 
 impl H3Acceptor for H3QuicheAcceptor {

--- a/tonic-h3-tests/src/lib.rs
+++ b/tonic-h3-tests/src/lib.rs
@@ -240,12 +240,18 @@ pub fn run_test_quiche_server(
     };
     let acceptor = tonic_h3::quiche::H3QuicheAcceptor::new(socket, &config)
         .expect("failed to bind quiche acceptor");
+    // Take a shutdown handle before the acceptor is moved into the serving task.
+    let endpoint = acceptor.endpoint();
     let h_sv = run_test_server(acceptor, token);
 
     let h = tokio::spawn(async move {
         h_sv.await
             .expect("cannot join")
             .expect("tonic server failed");
+        // Drain live connection workers so the UDP port is released promptly and
+        // can be rebound (see H3QuicheEndpoint::wait_idle docs).
+        endpoint.close(h3::error::Code::H3_NO_ERROR, b"svr shutdown");
+        endpoint.wait_idle().await;
         tracing::debug!("test quiche server ended");
     });
 

--- a/tonic-h3-tests/src/reconnect.rs
+++ b/tonic-h3-tests/src/reconnect.rs
@@ -33,7 +33,6 @@ async fn h3_msquic_test() {
 #[tokio::test]
 #[test_log::test]
 #[serial_test::serial(reconnect)]
-#[ignore = "quiche listener does not release the UDP socket promptly on shutdown (AddrInUse on rebind)"]
 async fn h3_quiche_test() {
     reconnect_test(crate::run_test_quiche_server, crate::run_quiche_client).await;
 }


### PR DESCRIPTION
## Summary

- Bump `msquic-h3` to **0.0.7** and `quiche-h3` to **0.0.2** (no API changes required for either).
- Use the new quiche-h3 0.0.2 `H3QuicheEndpoint::wait_idle` API to fix quiche server shutdown so the UDP port is released promptly.
- Enable the previously-`#[ignore]`d `reconnect::h3_quiche_test`.

## Details

`quiche-h3` 0.0.2 adds a cloneable `H3QuicheEndpoint` shutdown handle (`close()` / `wait_idle()`), analogous to quinn's `Endpoint::close`/`wait_idle`. This PR:

- Exposes `H3QuicheAcceptor::endpoint()` in `h3-util`.
- Drives `endpoint.close(H3_NO_ERROR, ...)` + `endpoint.wait_idle().await` from the quiche test server after the tonic serve task ends, draining live connection workers so the socket is freed. This mirrors the existing quinn server teardown pattern.
- Removes the `#[ignore = "quiche listener does not release the UDP socket promptly on shutdown (AddrInUse on rebind)"]` on `reconnect::h3_quiche_test`, which now passes (same-port rebind succeeds).

## Validation

- `cargo check`/`clippy` clean with `--features msquic` and `--features quiche`.
- `reconnect::h3_quiche_test` passes consistently (3/3 runs); `mix::h3_quiche_test` still passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>