### PR TITLE
Release 0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "axum-h3"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "axum",
  "futures",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "h3-util"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "bytes",
  "futures",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "tonic-h3"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "axum-h3",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,5 @@ quiche-h3 = "0.0.2"
 # crates in this workspace
 tonic-h3 = { path = "tonic-h3" }
 tonic-h3-s2n = { path = "tonic-h3-s2n" }
-h3-util = { version = "0.0.5", path = "h3-util" , default-features = false }
-axum-h3 = { version = "0.0.5", path = "axum-h3" }
+h3-util = { version = "0.0.6", path = "h3-util" , default-features = false }
+axum-h3 = { version = "0.0.6", path = "axum-h3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rcgen = { version = "0.14", default-features = false, features = ["crypto", "aws
 rustls = { version = "0.23", default-features = false, features = ["std", "aws_lc_rs"] }
 serial_test = "3"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
-tokio = { version = "1", default-features = false, features = ["full"] }
+tokio = { version = "1", default-features = false }
 tokio-util = "0.7"
 tonic = { version = "0.14", default-features = false, features = ["router", "codegen", "transport"] }
 tonic-prost-build = "0.14"

--- a/axum-h3/Cargo.toml
+++ b/axum-h3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-h3"
-version = "0.0.5"
+version = "0.0.6"
 edition.workspace = true
 license = "MIT"
 authors = ["youyuanwu@outlook.com"]

--- a/axum-h3/Cargo.toml
+++ b/axum-h3/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 
 [dependencies]
 axum.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros"] }
 h3-util.workspace = true
 hyper-util.workspace = true
 tracing.workspace = true

--- a/h3-util/Cargo.toml
+++ b/h3-util/Cargo.toml
@@ -24,7 +24,7 @@ test = false
 [dependencies]
 h3.workspace = true
 hyper.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["sync", "macros", "rt", "net"] }
 tracing.workspace = true
 futures.workspace = true
 tower.workspace = true

--- a/h3-util/Cargo.toml
+++ b/h3-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "h3-util"
-version = "0.0.5"
+version = "0.0.6"
 edition.workspace = true
 authors = ["youyuanwu@outlook.com"]
 description = "h3 utilities for tonic-h3"

--- a/tonic-h3-tests/Cargo.toml
+++ b/tonic-h3-tests/Cargo.toml
@@ -10,7 +10,7 @@ rcgen.workspace = true
 rustls.workspace = true
 serial_test.workspace = true
 test-log.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true
 tonic-h3 = {workspace = true, features = ["quinn", "msquic", "s2n-quic", "quiche"]}
 tonic.workspace = true

--- a/tonic-h3/Cargo.toml
+++ b/tonic-h3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-h3"
-version = "0.0.5"
+version = "0.0.6"
 edition.workspace = true
 license = "MIT"
 authors = ["youyuanwu@outlook.com"]


### PR DESCRIPTION
## Summary

Prepare the 0.0.6 release and clean up tokio feature declarations.

### Version bumps
- `tonic-h3` 0.0.5 → 0.0.6
- `axum-h3` 0.0.5 → 0.0.6
- `h3-util` 0.0.5 → 0.0.6

Also updates the workspace dependency version pins for `h3-util`/`axum-h3` and `Cargo.lock`.

### Per-crate tokio features
The workspace `tokio` dependency no longer pins `features = ["full"]`. A crate can add but **cannot remove** features declared on a `workspace = true` dependency, so pinning `full` at the workspace level forced every published crate to require the full tokio surface. Each crate now enables only what it uses:

| Crate | tokio features |
|---|---|
| workspace | *(none)* — `default-features = false` |
| h3-util | `sync, macros, rt, net` |
| axum-h3 | `macros` |
| tonic-h3 | *no direct tokio dependency* |
| tonic-h3-tests | `full` (unpublished) |

This reduces the tokio surface that downstream consumers of the published crates must build.

## Validation

- `cargo check` of the published crates in isolation (`-p h3-util -p axum-h3 -p tonic-h3`, quinn) — the tokio feature union is exactly `sync+macros+rt+net`, compiles clean.
- Full workspace `--all-targets` (all backends) and the test crate compile clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>