### PR TITLE
[gRPC Benchmark Harness] Add tonic-h3-bench echo benchmark suite (5 transports)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target
 obj
 bin
+# Rust source binary targets for the bench crate are real source, not build output.
+!tests/bench/src/bin/
 .vscode
 codecov.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,28 @@ name = "asn1-rs-impl"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -412,6 +440,44 @@ dependencies = [
  "libc",
  "libloading",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -1232,6 +1298,16 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
+dependencies = [
+ "byteorder",
+ "num-traits",
 ]
 
 [[package]]
@@ -3186,6 +3262,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3450,6 +3537,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3531,6 +3628,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-h3-bench"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "clap",
+ "futures",
+ "h3",
+ "h3-util",
+ "hdrhistogram",
+ "http",
+ "msquic",
+ "prost",
+ "quinn",
+ "rcgen",
+ "rustls",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tonic-h3",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tonic-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tonic-h3-test"
 version = "0.1.0"
 dependencies = [
@@ -3584,6 +3708,24 @@ dependencies = [
  "syn 2.0.119",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tonic-tls"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ace145c667504b488f44f08fd4966da7feefd430621a4ce1eae5ca79e6c867"
+dependencies = [
+ "async-stream",
+ "futures",
+ "hyper",
+ "hyper-util",
+ "socket2 0.6.5",
+ "tokio",
+ "tokio-rustls",
+ "tonic",
+ "tower",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [ "tonic-h3", "tonic-h3-tests", "h3-util", "axum-h3"]
+members = [ "tonic-h3", "tonic-h3-tests", "h3-util", "axum-h3", "tests/bench"]
 package.edition = "2024"
 
 [workspace.dependencies]
@@ -35,6 +35,11 @@ msquic = { version = "2.5.1-beta", default-features = false, features = ["find"]
 axum = {version = "0.8", default-features = false}
 http-body-util = "0.1"
 bytes = "1"
+
+# benchmark harness deps
+clap = { version = "4", default-features = false, features = ["std", "help", "usage", "error-context"] }
+tonic-tls = { version = "0.7", default-features = false }
+hdrhistogram = { version = "7", default-features = false }
 
 # quiche-h3 bridge crate (implements the h3::quic traits over tokio-quiche)
 quiche-h3 = "0.0.2"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Compatibility with grpc-dotnet with http3 is tested [here](./dotnet/).
 * [h3-util](./h3-util/) Http3 server and client utilities used by `axum-h3` and `tonic-h3`.
 * Other quic wrapping crates to support alternative quic implementations.
 
+## Benchmarks
+* [tests/bench](./tests/bench/) A gRPC echo benchmark harness (`bench-server` / `bench-client`) that compares throughput and latency across all transports (TCP+TLS baseline plus quinn/msquic/s2n-quic/quiche over HTTP/3).
+
 ## Get started
 Add deps to your cargo.toml
 ```toml

--- a/tests/bench/Cargo.toml
+++ b/tests/bench/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "tonic-h3-bench"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+description = "gRPC echo benchmark harness for tonic-h3 across TCP+TLS and QUIC transports"
+
+[lib]
+name = "tonic_h3_bench"
+path = "src/lib.rs"
+
+[[bin]]
+name = "bench-server"
+path = "src/bin/bench-server.rs"
+
+[[bin]]
+name = "bench-client"
+path = "src/bin/bench-client.rs"
+
+[dependencies]
+tonic-h3 = { workspace = true, features = ["quinn", "msquic", "s2n-quic", "quiche"] }
+tonic.workspace = true
+tonic-prost.workspace = true
+prost.workspace = true
+h3-util.workspace = true
+h3.workspace = true
+# need to enable rustls for quinn
+quinn = { workspace = true, default-features = false, features = ["aws-lc-rs", "rustls-aws-lc-rs", "runtime-tokio", "log"] }
+# link msquic native library
+msquic.workspace = true
+# TCP+TLS (HTTP/2) baseline
+tonic-tls = { workspace = true, features = ["rustls"] }
+rustls.workspace = true
+rcgen.workspace = true
+bytes.workspace = true
+futures.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tokio-util.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+http.workspace = true
+clap = { workspace = true, features = ["derive"] }
+hdrhistogram.workspace = true
+
+[build-dependencies]
+tonic-prost-build.workspace = true
+
+[package.metadata.rust-analyzer]
+cargo.loadOutDirsFromCheck = true

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -52,7 +52,11 @@ message EchoReply   { bytes payload = 1; }
 ```
 
 The server echoes the request payload back unchanged. The client fills each
-request with `--payload-size` zero bytes and verifies the reply length matches.
+request with a deterministic, non-uniform `--payload-size`-byte pattern. The
+**preflight self-check** compares the reply to the request **byte-for-byte**
+(validating transport correctness, FR-009); the measured hot path then checks
+only the reply **length**, keeping per-request overhead O(1) so the correctness
+check does not distort throughput numbers.
 
 ## Building
 
@@ -94,8 +98,28 @@ cargo run -p tonic-h3-bench --bin bench-server -- --transport tcp-tls --addr 127
 cargo run -p tonic-h3-bench --bin bench-client -- --transport tcp-tls --addr 127.0.0.1:5000 --count 50000
 ```
 
-**Experimental QUIC backends** (`msquic`, `s2n-quic`, `quiche`) use the same
-flags — just change `--transport`. For `quiche`, prefer `--concurrency 1`:
+**HTTP/3 over msquic (experimental):**
+
+```bash
+# server
+cargo run -p tonic-h3-bench --bin bench-server -- --transport msquic --addr 127.0.0.1:5000
+# client
+cargo run -p tonic-h3-bench --bin bench-client -- --transport msquic --addr 127.0.0.1:5000 \
+    --count 20000 --concurrency 16
+```
+
+**HTTP/3 over s2n-quic (experimental):**
+
+```bash
+# server
+cargo run -p tonic-h3-bench --bin bench-server -- --transport s2n-quic --addr 127.0.0.1:5000
+# client
+cargo run -p tonic-h3-bench --bin bench-client -- --transport s2n-quic --addr 127.0.0.1:5000 \
+    --count 20000 --concurrency 16
+```
+
+**HTTP/3 over quiche (experimental)** — prefer `--concurrency 1` (see the
+[caveat](#transports-compared)):
 
 ```bash
 cargo run -p tonic-h3-bench --bin bench-server -- --transport quiche --addr 127.0.0.1:5000
@@ -137,11 +161,12 @@ latency p99: 15.231 ms
 | `--transport`       | *(required)*       | Transport to connect with (must match the server).   |
 | `--addr`            | `127.0.0.1:5000`   | Server address to target (`host:port`).              |
 | `--payload-size`    | `64`               | Echo payload size in bytes.                          |
-| `--concurrency`     | `16`               | Number of concurrent in-flight workers.              |
+| `--concurrency`     | `16`               | Number of concurrent in-flight workers (must be >= 1; `0` is rejected). |
 | `--count`           | `10000`\*          | Total number of requests to send. Mutually exclusive with `--duration`. |
 | `--duration`        | *(unset)*          | Run for this many **seconds** instead of a fixed count. Mutually exclusive with `--count`. |
 | `--warmup`          | *(unset)*          | Optional warmup duration in **seconds**; warmup results are discarded. |
-| `--connect-timeout` | `5`                | Connect/preflight timeout in **seconds** (fail fast when the server is unreachable). |
+| `--connect-timeout` | `5`                | Connect/preflight timeout in **seconds** (fail fast when the server is unreachable). Also bounds the TCP+TLS connect/handshake. |
+| `--request-timeout` | `30`               | Per-request timeout in **seconds**. A request exceeding it is counted as a failure so runs always terminate even if a backend stalls. |
 
 \* `--count` has no clap-level default value; when **neither** `--count` nor
 `--duration` is supplied, the client falls back to a built-in default of
@@ -159,7 +184,9 @@ Each client run has three stages:
    sessions, and the allocator settle before measurement.
 3. **Measured run** — `--concurrency` worker tasks issue echo RPCs as fast as
    they can, either until `--count` requests have been sent (workers pull from a
-   shared atomic counter) or until `--duration` seconds elapse. Each worker
+   shared atomic counter) or until `--duration` seconds elapse. Each request is
+   bounded by `--request-timeout`; a request that exceeds it (or otherwise
+   errors) is counted as a **failure** rather than hanging the run. Each worker
    records per-request latency into a local histogram; the histograms are then
    merged.
 

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -1,0 +1,221 @@
+# tonic-h3 gRPC benchmark harness
+
+A self-contained load-testing suite that measures the throughput and latency of
+a gRPC **echo** service across every transport that `tonic-h3` supports, plus a
+vanilla `tonic` TCP+TLS baseline. It ships two binaries:
+
+- **`bench-server`** — serves the echo service over one selected transport.
+- **`bench-client`** — drives configurable load (concurrency, payload size,
+  request count or duration) and reports **throughput** (req/s) and **latency
+  percentiles** (p50 / p90 / p99).
+
+> This crate (`tonic-h3-bench`, `publish = false`) is a workspace-internal
+> benchmark tool. It uses self-signed certificates and a **dangerous
+> "accept any certificate" client verifier** so it can run on loopback without
+> a PKI — it is **not** an example of production-grade TLS configuration.
+
+## Transports compared
+
+The same echo RPC runs over five transports, selected with `--transport`:
+
+| `--transport` | Stack                              | Protocol         | Maturity        |
+|---------------|------------------------------------|------------------|-----------------|
+| `tcp-tls`     | `tonic` + `tonic-tls` (rustls)     | HTTP/2 over TCP  | baseline        |
+| `quinn`       | `tonic-h3` + quinn                 | HTTP/3 over QUIC | **production**  |
+| `msquic`      | `tonic-h3` + msquic                | HTTP/3 over QUIC | experimental    |
+| `s2n-quic`    | `tonic-h3` + s2n-quic              | HTTP/3 over QUIC | experimental    |
+| `quiche`      | `tonic-h3` + quiche                | HTTP/3 over QUIC | experimental    |
+
+> **Only the `quinn` backend is supported for production use.** `msquic`,
+> `s2n-quic`, and `quiche` are **experimental** and provided for evaluation
+> only, matching the support matrix in the [root README](../../README.md).
+>
+> **Known experimental-backend caveat:** the `quiche` client can stall under
+> high concurrency. Benchmark it with `--concurrency 1` for stable results
+> (see [Interpreting results](#interpreting-results)).
+
+The `tcp-tls` transport negotiates **HTTP/2** (ALPN `h2`); the four QUIC
+transports negotiate **HTTP/3** (ALPN `h3`). This lets you compare gRPC over
+HTTP/3/QUIC against the established gRPC-over-HTTP/2/TCP baseline.
+
+## The echo protocol
+
+A dedicated, minimal proto (`proto/echo.proto`) with a `bytes` payload so the
+client can vary the message size:
+
+```proto
+syntax = "proto3";
+package echo;
+service Echo { rpc Echo (EchoRequest) returns (EchoReply) {} }
+message EchoRequest { bytes payload = 1; }
+message EchoReply   { bytes payload = 1; }
+```
+
+The server echoes the request payload back unchanged. The client fills each
+request with `--payload-size` zero bytes and verifies the reply length matches.
+
+## Building
+
+The crate links **all** QUIC backends, so it needs the native `msquic` library
+available at build/link time (the workspace already provisions it in CI). Build
+just this crate:
+
+```bash
+cargo build -p tonic-h3-bench
+```
+
+This produces `target/debug/bench-server` and `target/debug/bench-client`.
+
+## Running a benchmark
+
+Start a server in one terminal, then point a client at it in another. The
+server prints the **actual** bound address (useful when binding to an ephemeral
+`:0` port).
+
+**HTTP/3 over quinn (production backend):**
+
+```bash
+# terminal 1 — server
+cargo run -p tonic-h3-bench --bin bench-server -- \
+    --transport quinn --addr 127.0.0.1:5000
+
+# terminal 2 — client: 50k requests, 32 concurrent workers, 4 KiB payload
+cargo run -p tonic-h3-bench --bin bench-client -- \
+    --transport quinn --addr 127.0.0.1:5000 \
+    --count 50000 --concurrency 32 --payload-size 4096
+```
+
+**HTTP/2 over TCP+TLS (baseline):**
+
+```bash
+# server
+cargo run -p tonic-h3-bench --bin bench-server -- --transport tcp-tls --addr 127.0.0.1:5000
+# client
+cargo run -p tonic-h3-bench --bin bench-client -- --transport tcp-tls --addr 127.0.0.1:5000 --count 50000
+```
+
+**Experimental QUIC backends** (`msquic`, `s2n-quic`, `quiche`) use the same
+flags — just change `--transport`. For `quiche`, prefer `--concurrency 1`:
+
+```bash
+cargo run -p tonic-h3-bench --bin bench-server -- --transport quiche --addr 127.0.0.1:5000
+cargo run -p tonic-h3-bench --bin bench-client -- --transport quiche --addr 127.0.0.1:5000 \
+    --count 20000 --concurrency 1
+```
+
+The server runs until it receives **Ctrl-C** (SIGINT) or **SIGTERM**, then runs
+the transport-specific graceful-shutdown recipe so the port is released
+promptly (no ~30 s QUIC idle-timeout hang). The client exits automatically when
+the run completes and prints the result; it returns a **non-zero exit code** if
+zero requests succeeded (e.g. the server was unreachable).
+
+Example client output:
+
+```
+=== Benchmark result ===
+requests:    50000 total (50000 ok, 0 failed)
+elapsed:     12.104 s
+throughput:  4131.7 req/s
+latency p50: 6.912 ms
+latency p90: 9.472 ms
+latency p99: 15.231 ms
+```
+
+## CLI reference
+
+### `bench-server`
+
+| Flag          | Default            | Description                                    |
+|---------------|--------------------|------------------------------------------------|
+| `--transport` | *(required)*       | One of `tcp-tls`, `quinn`, `msquic`, `s2n-quic`, `quiche`. |
+| `--addr`      | `127.0.0.1:5000`   | Address to bind (`host:port`). Use `:0` for an ephemeral port. |
+
+### `bench-client`
+
+| Flag                | Default            | Description                                          |
+|---------------------|--------------------|------------------------------------------------------|
+| `--transport`       | *(required)*       | Transport to connect with (must match the server).   |
+| `--addr`            | `127.0.0.1:5000`   | Server address to target (`host:port`).              |
+| `--payload-size`    | `64`               | Echo payload size in bytes.                          |
+| `--concurrency`     | `16`               | Number of concurrent in-flight workers.              |
+| `--count`           | `10000`\*          | Total number of requests to send. Mutually exclusive with `--duration`. |
+| `--duration`        | *(unset)*          | Run for this many **seconds** instead of a fixed count. Mutually exclusive with `--count`. |
+| `--warmup`          | *(unset)*          | Optional warmup duration in **seconds**; warmup results are discarded. |
+| `--connect-timeout` | `5`                | Connect/preflight timeout in **seconds** (fail fast when the server is unreachable). |
+
+\* `--count` has no clap-level default value; when **neither** `--count` nor
+`--duration` is supplied, the client falls back to a built-in default of
+`10000` requests.
+
+## Methodology
+
+Each client run has three stages:
+
+1. **Preflight probe** — a single bounded echo RPC (`--connect-timeout`). If it
+   times out or errors, the client fails fast instead of hanging, so a
+   misconfigured or down server is reported immediately.
+2. **Optional warmup** — if `--warmup N` is given, the client applies load for
+   `N` seconds and **discards** those samples, letting connections, TLS
+   sessions, and the allocator settle before measurement.
+3. **Measured run** — `--concurrency` worker tasks issue echo RPCs as fast as
+   they can, either until `--count` requests have been sent (workers pull from a
+   shared atomic counter) or until `--duration` seconds elapse. Each worker
+   records per-request latency into a local histogram; the histograms are then
+   merged.
+
+**Metrics:**
+
+- **Throughput** = **successful** request count ÷ wall-clock elapsed of the
+  measured run (failed requests are excluded from the rate).
+- **Latency percentiles** (p50/p90/p99) are computed from an
+  [`hdrhistogram`](https://docs.rs/hdrhistogram) recording per-request wall time
+  in microseconds. Only **successful** requests contribute latency samples;
+  failed requests are counted separately.
+
+**Environment notes:**
+
+- Certificates are self-signed for `localhost`/`127.0.0.1` and the client uses a
+  no-verification verifier — do not read anything into TLS-handshake cost beyond
+  "a real handshake happened".
+- Loopback runs measure protocol/stack overhead, **not** network behavior. For
+  latency- or bandwidth-sensitive comparisons, run client and server on separate
+  hosts (see the Azure infra in [`../infra`](../infra/README.md)).
+
+## Interpreting results
+
+- **Compare like with like.** Hold `--payload-size`, `--concurrency`, and the
+  request budget (`--count`/`--duration`) constant when comparing transports;
+  change only `--transport`.
+- **Use `--warmup`** for steady-state numbers. The first requests on a fresh
+  connection pay handshake and cold-cache costs that skew short runs.
+- **Throughput scales with `--concurrency`** up to the point where the server,
+  client, or transport saturates a core or the loopback path. A single worker
+  measures round-trip latency; many workers measure pipeline throughput.
+- **Watch the `failed` count and `elapsed`.** A non-zero `failed` count or an
+  `elapsed` far larger than the latency percentiles imply indicates instability
+  rather than throughput — e.g. the `quiche` backend stalls under high
+  concurrency, producing a few failures and a long tail. Re-run experimental
+  backends at `--concurrency 1` to confirm.
+- **Percentiles over averages.** p99 exposes tail latency (queueing, retransmit,
+  GC pauses) that a mean would hide; it is usually the most decision-relevant
+  number for RPC systems.
+
+## Layout
+
+```
+tests/bench/
+├── Cargo.toml            # package `tonic-h3-bench`, publish = false
+├── build.rs              # compiles proto/echo.proto with tonic-prost-build
+├── proto/echo.proto      # the echo service definition
+├── README.md             # this file
+└── src/
+    ├── lib.rs            # proto include, EchoService, Transport enum, clap args
+    ├── tls.rs            # self-signed cert + ALPN-parameterized rustls configs
+    ├── server.rs         # per-transport serve + graceful-teardown recipes
+    ├── client.rs         # per-transport channel construction
+    ├── load.rs           # generic concurrent load generator
+    ├── metrics.rs        # hdrhistogram recorder + result summary
+    └── bin/
+        ├── bench-server.rs
+        └── bench-client.rs
+```

--- a/tests/bench/build.rs
+++ b/tests/bench/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_prost_build::compile_protos("proto/echo.proto")?;
+    Ok(())
+}

--- a/tests/bench/proto/echo.proto
+++ b/tests/bench/proto/echo.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package echo;
+
+// A minimal echo service used for transport benchmarking. The request payload
+// is returned unchanged in the reply. Using a `bytes` payload lets the client
+// vary message size to explore small-control-message and large-payload regimes.
+service Echo {
+  rpc Echo (EchoRequest) returns (EchoReply) {}
+}
+
+message EchoRequest {
+  bytes payload = 1;
+}
+
+message EchoReply {
+  bytes payload = 1;
+}

--- a/tests/bench/src/bin/bench-client.rs
+++ b/tests/bench/src/bin/bench-client.rs
@@ -1,0 +1,25 @@
+use clap::Parser;
+use tonic_h3_bench::cli::ClientArgs;
+use tonic_h3_bench::{BenchError, client::run_client, init_tracing};
+
+#[tokio::main]
+async fn main() -> Result<(), BenchError> {
+    let args = ClientArgs::parse();
+    init_tracing();
+
+    tracing::info!(
+        "starting bench-client: transport={} addr={} payload={}B concurrency={}",
+        args.transport,
+        args.addr,
+        args.payload_size,
+        args.concurrency
+    );
+
+    let summary = run_client(&args).await?;
+    println!("{summary}");
+
+    if summary.success == 0 {
+        return Err("no successful requests".into());
+    }
+    Ok(())
+}

--- a/tests/bench/src/bin/bench-server.rs
+++ b/tests/bench/src/bin/bench-server.rs
@@ -1,0 +1,53 @@
+use clap::Parser;
+use tonic_h3_bench::cli::ServerArgs;
+use tonic_h3_bench::{BenchError, init_tracing, server::run_server};
+
+#[tokio::main]
+async fn main() -> Result<(), BenchError> {
+    let args = ServerArgs::parse();
+    init_tracing();
+
+    let addr = args
+        .addr
+        .parse()
+        .map_err(|e| format!("invalid --addr `{}`: {e}", args.addr))?;
+
+    tracing::info!(
+        "starting bench-server: transport={} addr={}",
+        args.transport,
+        addr
+    );
+
+    // Serve until Ctrl-C.
+    let shutdown = async {
+        wait_for_shutdown_signal().await;
+        tracing::info!("shutdown signal received");
+    };
+
+    run_server(args.transport, addr, shutdown).await?;
+    tracing::info!("bench-server stopped");
+    Ok(())
+}
+
+/// Resolve on the first of SIGINT (Ctrl-C) or, on Unix, SIGTERM.
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(_) => {
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = term.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}

--- a/tests/bench/src/client.rs
+++ b/tests/bench/src/client.rs
@@ -39,10 +39,49 @@ pub async fn run_client(args: &ClientArgs) -> Result<BenchSummary, BenchError> {
             endpoint.close(0u16.into(), b"client done");
             Ok(summary)
         }
-        other => Err(format!(
-            "client transport `{other}` is not implemented yet (added in a later phase)"
-        )
-        .into()),
+        Transport::S2nQuic => {
+            let s2n_ep = make_s2n_client_endpoint()?;
+            let connector = h3_util::s2n::client::H3S2nConnector::new(
+                uri.clone(),
+                "localhost".to_string(),
+                s2n_ep,
+            );
+            let channel = tonic_h3::H3Channel::new(connector, uri.clone(), None);
+            let client = EchoClient::new(channel);
+            let summary = drive_load(client, cfg).await?;
+            // s2n has no close; the client process exits immediately after.
+            Ok(summary)
+        }
+        Transport::Quiche => {
+            use h3_util::quiche_h3::H3QuicheClientConfig;
+            let connector = tonic_h3::quiche::H3QuicheConnector::new(
+                uri.clone(),
+                "localhost".to_string(),
+                H3QuicheClientConfig {
+                    verify_peer: false,
+                    ..Default::default()
+                },
+            );
+            let channel = tonic_h3::H3Channel::new(connector, uri.clone(), None);
+            let client = EchoClient::new(channel);
+            let summary = drive_load(client, cfg).await?;
+            // The quiche connector holds no persistent endpoint; nothing to close.
+            Ok(summary)
+        }
+        Transport::Msquic => {
+            let (reg, config) = make_msquic_client_parts()?;
+            let connector =
+                h3_util::msquic::client::H3MsQuicConnector::new(config, reg.clone(), uri.clone());
+            let channel = tonic_h3::H3Channel::new(connector, uri.clone(), None);
+            let client = EchoClient::new(channel);
+            let summary = drive_load(client, cfg).await?;
+            // Teardown: shut down the registration, wait idle, then drop so the
+            // final RegistrationClose does not block the runtime.
+            reg.shutdown();
+            reg.wait_idle().await;
+            std::mem::drop(reg);
+            Ok(summary)
+        }
     }
 }
 
@@ -74,4 +113,52 @@ async fn connect_tcp_tls(addr: &str) -> Result<tonic::transport::Channel, BenchE
         ))
         .await?;
     Ok(channel)
+}
+
+/// Build an s2n-quic client endpoint using the dangerous (no-verify) h3 config.
+fn make_s2n_client_endpoint() -> Result<h3_util::s2n::s2n_quic::Client, BenchError> {
+    use h3_util::s2n::s2n_quic;
+
+    let tls =
+        s2n_quic::provider::tls::rustls::Client::from(tls::make_danger_client_config(&[b"h3"]));
+    let client = s2n_quic::Client::builder()
+        .with_tls(tls)
+        .map_err(|e| format!("s2n tls provider: {e}"))?
+        .with_io("0.0.0.0:0")
+        .map_err(|e| format!("s2n io: {e}"))?
+        .start()
+        .map_err(|e| format!("s2n start: {e}"))?;
+    Ok(client)
+}
+
+/// Build msquic client registration + configuration (no-verify h3).
+#[allow(clippy::type_complexity)]
+fn make_msquic_client_parts() -> Result<
+    (
+        Arc<h3_util::msquic::msquic_h3::Registration>,
+        Arc<h3_util::msquic::msquic_h3::msquic::Configuration>,
+    ),
+    BenchError,
+> {
+    use h3_util::msquic::msquic_h3::{self, msquic};
+
+    let reg = msquic_h3::Registration::new(
+        &msquic::RegistrationConfig::new().set_app_name("benchapp_client".to_string()),
+    )
+    .map_err(|e| format!("msquic registration: {e}"))?;
+
+    let alpn = msquic::BufferRef::from("h3");
+    let client_settings = msquic::Settings::new()
+        .set_IdleTimeoutMs(1000)
+        .set_PeerBidiStreamCount(10)
+        .set_PeerUnidiStreamCount(10);
+    let client_config = reg
+        .open_configuration(&[alpn], Some(&client_settings))
+        .map_err(|e| format!("msquic configuration: {e}"))?;
+    let cred_config = msquic::CredentialConfig::new_client()
+        .set_credential_flags(msquic::CredentialFlags::NO_CERTIFICATE_VALIDATION);
+    client_config
+        .load_credential(&cred_config)
+        .map_err(|e| format!("msquic load_credential: {e}"))?;
+    Ok((reg.into(), client_config.into()))
 }

--- a/tests/bench/src/client.rs
+++ b/tests/bench/src/client.rs
@@ -1,0 +1,52 @@
+//! Transport-dispatching benchmark client.
+//!
+//! Each arm builds the appropriate channel, wraps it in the generated
+//! `EchoClient`, and runs the shared [`crate::load::drive_load`] loop.
+
+use std::sync::Arc;
+
+use http::Uri;
+
+use crate::cli::ClientArgs;
+use crate::echo_client::EchoClient;
+use crate::load::drive_load;
+use crate::metrics::BenchSummary;
+use crate::{BenchError, Transport, tls};
+
+/// Connect with the selected transport and drive the configured load.
+pub async fn run_client(args: &ClientArgs) -> Result<BenchSummary, BenchError> {
+    let uri: Uri = format!("https://{}", args.addr).parse()?;
+    let cfg = args.load_config();
+
+    match args.transport {
+        Transport::Quinn => {
+            let endpoint = make_quinn_client_endpoint()?;
+            let connector = tonic_h3::quinn::H3QuinnConnector::new(
+                uri.clone(),
+                "localhost".to_string(),
+                endpoint.clone(),
+            );
+            let channel = tonic_h3::H3Channel::new(connector, uri.clone(), None);
+            let client = EchoClient::new(channel);
+            let summary = drive_load(client, cfg).await?;
+            // Client teardown: explicit close is preferred over wait_idle.
+            endpoint.close(0u16.into(), b"client done");
+            Ok(summary)
+        }
+        other => Err(format!(
+            "client transport `{other}` is not implemented yet (added in a later phase)"
+        )
+        .into()),
+    }
+}
+
+/// Build a quinn client endpoint using the dangerous (no-verify) h3 config.
+fn make_quinn_client_endpoint() -> Result<quinn::Endpoint, BenchError> {
+    use quinn::crypto::rustls::QuicClientConfig;
+
+    let tls_config = tls::make_danger_client_config(&[b"h3"]);
+    let mut endpoint = quinn::Endpoint::client("[::]:0".parse()?)?;
+    let client_config = quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(tls_config)?));
+    endpoint.set_default_client_config(client_config);
+    Ok(endpoint)
+}

--- a/tests/bench/src/client.rs
+++ b/tests/bench/src/client.rs
@@ -19,6 +19,12 @@ pub async fn run_client(args: &ClientArgs) -> Result<BenchSummary, BenchError> {
     let cfg = args.load_config();
 
     match args.transport {
+        Transport::TcpTls => {
+            let channel = connect_tcp_tls(&args.addr).await?;
+            let client = EchoClient::new(channel);
+            let summary = drive_load(client, cfg).await?;
+            Ok(summary)
+        }
         Transport::Quinn => {
             let endpoint = make_quinn_client_endpoint()?;
             let connector = tonic_h3::quinn::H3QuinnConnector::new(
@@ -49,4 +55,23 @@ fn make_quinn_client_endpoint() -> Result<quinn::Endpoint, BenchError> {
     let client_config = quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(tls_config)?));
     endpoint.set_default_client_config(client_config);
     Ok(endpoint)
+}
+
+/// Build a tonic `Channel` over TCP+TLS (HTTP/2, ALPN "h2") via `tonic-tls`.
+async fn connect_tcp_tls(addr: &str) -> Result<tonic::transport::Channel, BenchError> {
+    use rustls::pki_types::ServerName;
+    use tonic::transport::Endpoint;
+
+    let endpoint = Endpoint::from_shared(format!("https://{addr}"))?;
+    let dnsname = ServerName::try_from("localhost")?.to_owned();
+    let client_config = Arc::new(tls::make_danger_client_config(&[b"h2"]));
+    let transport = tonic_tls::TcpTransport::from_endpoint(&endpoint);
+    let channel = endpoint
+        .connect_with_connector(tonic_tls::rustls::TlsConnector::new(
+            transport,
+            client_config,
+            dnsname,
+        ))
+        .await?;
+    Ok(channel)
 }

--- a/tests/bench/src/client.rs
+++ b/tests/bench/src/client.rs
@@ -20,10 +20,26 @@ pub async fn run_client(args: &ClientArgs) -> Result<BenchSummary, BenchError> {
 
     match args.transport {
         Transport::TcpTls => {
-            let channel = connect_tcp_tls(&args.addr).await?;
+            // Bound the eager TCP connect + TLS handshake by the connect timeout
+            // so a stalled SYN/handshake fails fast (the preflight RPC timeout
+            // only covers the request, not this pre-connection step).
+            let channel = match tokio::time::timeout(
+                cfg.connect_timeout,
+                connect_tcp_tls(&args.addr),
+            )
+            .await
+            {
+                Ok(res) => res?,
+                Err(_) => {
+                    return Err(format!(
+                        "tcp-tls connect timed out after {:?}; is the server running?",
+                        cfg.connect_timeout
+                    )
+                    .into());
+                }
+            };
             let client = EchoClient::new(channel);
-            let summary = drive_load(client, cfg).await?;
-            Ok(summary)
+            drive_load(client, cfg).await
         }
         Transport::Quinn => {
             let endpoint = make_quinn_client_endpoint()?;
@@ -34,10 +50,11 @@ pub async fn run_client(args: &ClientArgs) -> Result<BenchSummary, BenchError> {
             );
             let channel = tonic_h3::H3Channel::new(connector, uri.clone(), None);
             let client = EchoClient::new(channel);
-            let summary = drive_load(client, cfg).await?;
+            // Capture the result so teardown always runs, even on error.
+            let result = drive_load(client, cfg).await;
             // Client teardown: explicit close is preferred over wait_idle.
             endpoint.close(0u16.into(), b"client done");
-            Ok(summary)
+            result
         }
         Transport::S2nQuic => {
             let s2n_ep = make_s2n_client_endpoint()?;
@@ -48,9 +65,8 @@ pub async fn run_client(args: &ClientArgs) -> Result<BenchSummary, BenchError> {
             );
             let channel = tonic_h3::H3Channel::new(connector, uri.clone(), None);
             let client = EchoClient::new(channel);
-            let summary = drive_load(client, cfg).await?;
             // s2n has no close; the client process exits immediately after.
-            Ok(summary)
+            drive_load(client, cfg).await
         }
         Transport::Quiche => {
             use h3_util::quiche_h3::H3QuicheClientConfig;
@@ -64,9 +80,8 @@ pub async fn run_client(args: &ClientArgs) -> Result<BenchSummary, BenchError> {
             );
             let channel = tonic_h3::H3Channel::new(connector, uri.clone(), None);
             let client = EchoClient::new(channel);
-            let summary = drive_load(client, cfg).await?;
             // The quiche connector holds no persistent endpoint; nothing to close.
-            Ok(summary)
+            drive_load(client, cfg).await
         }
         Transport::Msquic => {
             let (reg, config) = make_msquic_client_parts()?;
@@ -74,13 +89,14 @@ pub async fn run_client(args: &ClientArgs) -> Result<BenchSummary, BenchError> {
                 h3_util::msquic::client::H3MsQuicConnector::new(config, reg.clone(), uri.clone());
             let channel = tonic_h3::H3Channel::new(connector, uri.clone(), None);
             let client = EchoClient::new(channel);
-            let summary = drive_load(client, cfg).await?;
+            // Capture the result so registration teardown always runs.
+            let result = drive_load(client, cfg).await;
             // Teardown: shut down the registration, wait idle, then drop so the
             // final RegistrationClose does not block the runtime.
             reg.shutdown();
             reg.wait_idle().await;
             std::mem::drop(reg);
-            Ok(summary)
+            result
         }
     }
 }
@@ -148,10 +164,13 @@ fn make_msquic_client_parts() -> Result<
     .map_err(|e| format!("msquic registration: {e}"))?;
 
     let alpn = msquic::BufferRef::from("h3");
+    // Allow enough peer-initiated streams for benchmark concurrency (each
+    // in-flight echo RPC opens a bidirectional stream). Kept well above the
+    // client's default/typical worker counts so msquic is not stream-starved.
     let client_settings = msquic::Settings::new()
         .set_IdleTimeoutMs(1000)
-        .set_PeerBidiStreamCount(10)
-        .set_PeerUnidiStreamCount(10);
+        .set_PeerBidiStreamCount(1024)
+        .set_PeerUnidiStreamCount(1024);
     let client_config = reg
         .open_configuration(&[alpn], Some(&client_settings))
         .map_err(|e| format!("msquic configuration: {e}"))?;

--- a/tests/bench/src/lib.rs
+++ b/tests/bench/src/lib.rs
@@ -113,9 +113,9 @@ pub mod cli {
         #[arg(long, default_value_t = 64)]
         pub payload_size: usize,
 
-        /// Number of concurrent in-flight workers.
-        #[arg(long, default_value_t = 16)]
-        pub concurrency: usize,
+        /// Number of concurrent in-flight workers (must be >= 1).
+        #[arg(long, default_value_t = 16, value_parser = clap::value_parser!(u32).range(1..))]
+        pub concurrency: u32,
 
         /// Total number of requests to send (mutually exclusive with --duration).
         #[arg(long, group = "load")]
@@ -133,6 +133,11 @@ pub mod cli {
         /// Connect/preflight timeout in seconds (fail fast when unreachable).
         #[arg(long, default_value_t = 5)]
         pub connect_timeout: u64,
+
+        /// Per-request timeout in seconds. A request exceeding this is counted
+        /// as a failure, so runs always terminate even if a backend stalls.
+        #[arg(long, default_value_t = 30)]
+        pub request_timeout: u64,
     }
 
     impl ClientArgs {
@@ -153,10 +158,11 @@ pub mod cli {
         pub fn load_config(&self) -> LoadConfig {
             LoadConfig {
                 payload_size: self.payload_size,
-                concurrency: self.concurrency,
+                concurrency: self.concurrency as usize,
                 limit: self.limit(),
                 warmup: self.warmup.map(Duration::from_secs),
                 connect_timeout: Duration::from_secs(self.connect_timeout),
+                request_timeout: Duration::from_secs(self.request_timeout),
             }
         }
     }
@@ -201,6 +207,18 @@ pub mod cli {
             let a =
                 ClientArgs::try_parse_from(["bench-client", "--transport", "s2n-quic"]).unwrap();
             assert_eq!(a.transport, Transport::S2nQuic);
+        }
+
+        #[test]
+        fn zero_concurrency_is_rejected() {
+            let r = ClientArgs::try_parse_from([
+                "bench-client",
+                "--transport",
+                "quinn",
+                "--concurrency",
+                "0",
+            ]);
+            assert!(r.is_err(), "--concurrency 0 must be rejected");
         }
 
         #[test]

--- a/tests/bench/src/lib.rs
+++ b/tests/bench/src/lib.rs
@@ -1,0 +1,226 @@
+//! gRPC echo benchmark harness for tonic-h3.
+//!
+//! This crate provides a shared library plus two binaries (`bench-server` and
+//! `bench-client`) that measure a gRPC **echo** workload across five transports:
+//! a TCP+TLS (HTTP/2) baseline via `tonic-tls`, and tonic-h3 (HTTP/3) over
+//! `quinn`, `msquic`, `s2n-quic`, and `quiche`.
+//!
+//! Only the `quinn` backend is production-supported; `msquic`, `s2n-quic`, and
+//! `quiche` are experimental. See `tests/bench/README.md` for usage.
+
+pub mod client;
+pub mod load;
+pub mod metrics;
+pub mod server;
+pub mod tls;
+
+// Generated echo service (package `echo`): `echo_server`, `echo_client`,
+// `EchoRequest`, `EchoReply`.
+tonic::include_proto!("echo");
+
+/// Convenience error type for the harness.
+pub type BenchError = Box<dyn std::error::Error + Send + Sync>;
+
+/// The transport under test. Rendered by clap as `tcp-tls`, `quinn`, `msquic`,
+/// `s2n-quic`, `quiche`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum Transport {
+    /// tonic gRPC over TCP + TLS (HTTP/2). Baseline.
+    TcpTls,
+    /// tonic-h3 over quinn (HTTP/3). Production-supported.
+    Quinn,
+    /// tonic-h3 over msquic (HTTP/3). Experimental.
+    Msquic,
+    /// tonic-h3 over s2n-quic (HTTP/3). Experimental.
+    S2nQuic,
+    /// tonic-h3 over quiche (HTTP/3). Experimental.
+    Quiche,
+}
+
+impl std::fmt::Display for Transport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Transport::TcpTls => "tcp-tls",
+            Transport::Quinn => "quinn",
+            Transport::Msquic => "msquic",
+            Transport::S2nQuic => "s2n-quic",
+            Transport::Quiche => "quiche",
+        };
+        f.write_str(s)
+    }
+}
+
+/// The echo service implementation: returns the request payload unchanged.
+#[derive(Default, Clone)]
+pub struct EchoService;
+
+#[tonic::async_trait]
+impl echo_server::Echo for EchoService {
+    async fn echo(
+        &self,
+        req: tonic::Request<EchoRequest>,
+    ) -> Result<tonic::Response<EchoReply>, tonic::Status> {
+        let payload = req.into_inner().payload;
+        Ok(tonic::Response::new(EchoReply { payload }))
+    }
+}
+
+/// Build the tonic `Routes` serving the echo service (used by the H3 backends).
+pub fn echo_routes() -> tonic::service::Routes {
+    let mut builder = tonic::service::Routes::builder();
+    builder.add_service(echo_server::EchoServer::new(EchoService));
+    builder.routes()
+}
+
+/// CLI argument definitions (kept in the library so they can be unit-tested).
+pub mod cli {
+    use super::Transport;
+    use crate::load::{LoadConfig, LoadLimit};
+    use clap::Parser;
+    use std::time::Duration;
+
+    const DEFAULT_ADDR: &str = "127.0.0.1:5000";
+
+    /// `bench-server` arguments.
+    #[derive(Parser, Debug)]
+    #[command(name = "bench-server", about = "gRPC echo benchmark server")]
+    pub struct ServerArgs {
+        /// Transport to serve.
+        #[arg(long, value_enum)]
+        pub transport: Transport,
+
+        /// Address to bind (host:port).
+        #[arg(long, default_value = DEFAULT_ADDR)]
+        pub addr: String,
+    }
+
+    /// `bench-client` arguments.
+    #[derive(Parser, Debug)]
+    #[command(
+        name = "bench-client",
+        about = "gRPC echo benchmark client / load generator"
+    )]
+    pub struct ClientArgs {
+        /// Transport to connect with.
+        #[arg(long, value_enum)]
+        pub transport: Transport,
+
+        /// Server address to target (host:port).
+        #[arg(long, default_value = DEFAULT_ADDR)]
+        pub addr: String,
+
+        /// Echo payload size in bytes.
+        #[arg(long, default_value_t = 64)]
+        pub payload_size: usize,
+
+        /// Number of concurrent in-flight workers.
+        #[arg(long, default_value_t = 16)]
+        pub concurrency: usize,
+
+        /// Total number of requests to send (mutually exclusive with --duration).
+        #[arg(long, group = "load")]
+        pub count: Option<u64>,
+
+        /// Run for this many seconds instead of a fixed count (mutually
+        /// exclusive with --count).
+        #[arg(long, group = "load")]
+        pub duration: Option<u64>,
+
+        /// Optional warmup duration in seconds (results discarded).
+        #[arg(long)]
+        pub warmup: Option<u64>,
+
+        /// Connect/preflight timeout in seconds (fail fast when unreachable).
+        #[arg(long, default_value_t = 5)]
+        pub connect_timeout: u64,
+    }
+
+    impl ClientArgs {
+        /// Default request count when neither --count nor --duration is given.
+        pub const DEFAULT_COUNT: u64 = 10_000;
+
+        /// Resolve the load limit (defaults to a fixed count).
+        pub fn limit(&self) -> LoadLimit {
+            match (self.count, self.duration) {
+                // clap's mutually-exclusive group prevents both being set.
+                (_, Some(d)) => LoadLimit::Duration(Duration::from_secs(d)),
+                (Some(n), None) => LoadLimit::Count(n),
+                (None, None) => LoadLimit::Count(Self::DEFAULT_COUNT),
+            }
+        }
+
+        /// Build a [`LoadConfig`] from these arguments.
+        pub fn load_config(&self) -> LoadConfig {
+            LoadConfig {
+                payload_size: self.payload_size,
+                concurrency: self.concurrency,
+                limit: self.limit(),
+                warmup: self.warmup.map(Duration::from_secs),
+                connect_timeout: Duration::from_secs(self.connect_timeout),
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn count_and_duration_are_mutually_exclusive() {
+            let r = ClientArgs::try_parse_from([
+                "bench-client",
+                "--transport",
+                "quinn",
+                "--count",
+                "5",
+                "--duration",
+                "3",
+            ]);
+            assert!(
+                r.is_err(),
+                "supplying both --count and --duration must error"
+            );
+        }
+
+        #[test]
+        fn defaults_apply_when_not_specified() {
+            let a = ClientArgs::try_parse_from(["bench-client", "--transport", "quinn"]).unwrap();
+            assert_eq!(a.payload_size, 64);
+            assert_eq!(a.concurrency, 16);
+            assert_eq!(a.connect_timeout, 5);
+            assert!(a.count.is_none());
+            assert!(a.duration.is_none());
+            assert!(matches!(
+                a.limit(),
+                LoadLimit::Count(ClientArgs::DEFAULT_COUNT)
+            ));
+        }
+
+        #[test]
+        fn transport_value_enum_parses_kebab_case() {
+            let a =
+                ClientArgs::try_parse_from(["bench-client", "--transport", "s2n-quic"]).unwrap();
+            assert_eq!(a.transport, Transport::S2nQuic);
+        }
+
+        #[test]
+        fn duration_limit_selected() {
+            let a = ClientArgs::try_parse_from([
+                "bench-client",
+                "--transport",
+                "quinn",
+                "--duration",
+                "7",
+            ])
+            .unwrap();
+            assert!(matches!(a.limit(), LoadLimit::Duration(d) if d == Duration::from_secs(7)));
+        }
+    }
+}
+
+/// Install a simple tracing subscriber honoring `RUST_LOG` (defaults to info).
+pub fn init_tracing() {
+    use tracing_subscriber::EnvFilter;
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
+}

--- a/tests/bench/src/load.rs
+++ b/tests/bench/src/load.rs
@@ -1,0 +1,192 @@
+//! Generic load generator for the benchmark client.
+//!
+//! [`drive_load`] is generic over the tonic channel type, so the same worker
+//! loop and metrics collection run for both the HTTP/3 `H3Channel` and the
+//! HTTP/2 `tonic::transport::Channel`. The generic `where` clause mirrors the
+//! bound set that generated tonic clients declare.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+// Brings `Body`, `Bytes`, and `StdError` into scope (same imports the generated
+// client `impl` block uses).
+use tonic::codegen::*;
+
+use crate::echo_client::EchoClient;
+use crate::metrics::{BenchSummary, Recorder};
+use crate::{BenchError, EchoRequest};
+
+/// How much load to apply: a fixed request count or a wall-clock duration.
+#[derive(Debug, Clone, Copy)]
+pub enum LoadLimit {
+    Count(u64),
+    Duration(Duration),
+}
+
+/// Configuration for one benchmark run.
+#[derive(Debug, Clone)]
+pub struct LoadConfig {
+    pub payload_size: usize,
+    pub concurrency: usize,
+    pub limit: LoadLimit,
+    pub warmup: Option<Duration>,
+    pub connect_timeout: Duration,
+}
+
+/// Drive load against `client` and return the aggregated summary.
+///
+/// Performs a bounded preflight probe first so a missing/unreachable server
+/// fails fast (returning `Err`) instead of hanging.
+pub async fn drive_load<T>(
+    client: EchoClient<T>,
+    cfg: LoadConfig,
+) -> Result<BenchSummary, BenchError>
+where
+    T: tonic::client::GrpcService<tonic::body::Body> + Clone + Send + 'static,
+    T::Error: Into<StdError>,
+    T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+    <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    T::Future: Send,
+{
+    // --- Preflight probe (fail fast) ---
+    {
+        let mut c = client.clone();
+        let payload = vec![0u8; cfg.payload_size];
+        let fut = c.echo(tonic::Request::new(EchoRequest {
+            payload: payload.clone(),
+        }));
+        match tokio::time::timeout(cfg.connect_timeout, fut).await {
+            Err(_) => {
+                return Err(format!(
+                    "connect probe timed out after {:?}; is the server running?",
+                    cfg.connect_timeout
+                )
+                .into());
+            }
+            Ok(Err(e)) => {
+                return Err(format!("connect probe failed: {e}").into());
+            }
+            Ok(Ok(resp)) => {
+                if resp.into_inner().payload.len() != cfg.payload_size {
+                    return Err("echo self-check failed: reply payload size mismatch".into());
+                }
+            }
+        }
+    }
+
+    // --- Optional warmup (results discarded) ---
+    if let Some(w) = cfg.warmup {
+        let _ = run_duration(&client, cfg.payload_size, cfg.concurrency, w).await;
+    }
+
+    // --- Measured run ---
+    let start = Instant::now();
+    let rec = match cfg.limit {
+        LoadLimit::Count(n) => run_count(&client, cfg.payload_size, cfg.concurrency, n).await,
+        LoadLimit::Duration(d) => run_duration(&client, cfg.payload_size, cfg.concurrency, d).await,
+    };
+    let elapsed = start.elapsed();
+    Ok(BenchSummary::from_recorder(&rec, elapsed))
+}
+
+/// Issue a single echo RPC, recording latency (success) or a failure.
+async fn one_request<T>(client: &mut EchoClient<T>, payload_size: usize, rec: &mut Recorder)
+where
+    T: tonic::client::GrpcService<tonic::body::Body> + Clone + Send + 'static,
+    T::Error: Into<StdError>,
+    T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+    <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    T::Future: Send,
+{
+    let payload = vec![0u8; payload_size];
+    let start = Instant::now();
+    let req = tonic::Request::new(EchoRequest { payload });
+    match client.echo(req).await {
+        Ok(resp) => {
+            let lat = start.elapsed();
+            if resp.into_inner().payload.len() == payload_size {
+                rec.record_success(lat);
+            } else {
+                rec.record_failure();
+            }
+        }
+        Err(_) => rec.record_failure(),
+    }
+}
+
+/// Run `total` requests spread across `concurrency` workers pulling from a
+/// shared counter, then merge the per-worker recorders.
+async fn run_count<T>(
+    client: &EchoClient<T>,
+    payload_size: usize,
+    concurrency: usize,
+    total: u64,
+) -> Recorder
+where
+    T: tonic::client::GrpcService<tonic::body::Body> + Clone + Send + 'static,
+    T::Error: Into<StdError>,
+    T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+    <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    T::Future: Send,
+{
+    let counter = Arc::new(AtomicU64::new(0));
+    let mut handles = Vec::new();
+    for _ in 0..concurrency.max(1) {
+        let mut c = client.clone();
+        let counter = counter.clone();
+        handles.push(tokio::spawn(async move {
+            let mut rec = Recorder::new();
+            loop {
+                let n = counter.fetch_add(1, Ordering::Relaxed);
+                if n >= total {
+                    break;
+                }
+                one_request(&mut c, payload_size, &mut rec).await;
+            }
+            rec
+        }));
+    }
+    let mut merged = Recorder::new();
+    for h in handles {
+        if let Ok(r) = h.await {
+            merged.merge(&r);
+        }
+    }
+    merged
+}
+
+/// Run for `dur` wall-clock time across `concurrency` workers.
+async fn run_duration<T>(
+    client: &EchoClient<T>,
+    payload_size: usize,
+    concurrency: usize,
+    dur: Duration,
+) -> Recorder
+where
+    T: tonic::client::GrpcService<tonic::body::Body> + Clone + Send + 'static,
+    T::Error: Into<StdError>,
+    T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+    <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    T::Future: Send,
+{
+    let deadline = Instant::now() + dur;
+    let mut handles = Vec::new();
+    for _ in 0..concurrency.max(1) {
+        let mut c = client.clone();
+        handles.push(tokio::spawn(async move {
+            let mut rec = Recorder::new();
+            while Instant::now() < deadline {
+                one_request(&mut c, payload_size, &mut rec).await;
+            }
+            rec
+        }));
+    }
+    let mut merged = Recorder::new();
+    for h in handles {
+        if let Ok(r) = h.await {
+            merged.merge(&r);
+        }
+    }
+    merged
+}

--- a/tests/bench/src/load.rs
+++ b/tests/bench/src/load.rs
@@ -32,6 +32,18 @@ pub struct LoadConfig {
     pub limit: LoadLimit,
     pub warmup: Option<Duration>,
     pub connect_timeout: Duration,
+    /// Per-request timeout. A request that exceeds this is counted as a failure
+    /// so count- and duration-based runs always terminate (guards against a
+    /// stalled backend, e.g. the experimental quiche path under concurrency).
+    pub request_timeout: Duration,
+}
+
+/// Build a deterministic, non-uniform payload of `size` bytes.
+///
+/// A non-constant pattern lets the preflight self-check validate payload
+/// *content* (byte-for-byte), not merely length (FR-009).
+pub(crate) fn make_payload(size: usize) -> Vec<u8> {
+    (0..size).map(|i| (i % 251) as u8).collect()
 }
 
 /// Drive load against `client` and return the aggregated summary.
@@ -50,11 +62,14 @@ where
     T::Future: Send,
 {
     // --- Preflight probe (fail fast) ---
+    // Full byte-for-byte self-check (FR-009): a non-uniform payload is sent and
+    // the reply must match exactly. The measured hot path below only checks
+    // length, to keep per-request overhead O(1) (metrics NFR).
+    let payload = Arc::new(make_payload(cfg.payload_size));
     {
         let mut c = client.clone();
-        let payload = vec![0u8; cfg.payload_size];
         let fut = c.echo(tonic::Request::new(EchoRequest {
-            payload: payload.clone(),
+            payload: payload.as_ref().clone(),
         }));
         match tokio::time::timeout(cfg.connect_timeout, fut).await {
             Err(_) => {
@@ -68,8 +83,12 @@ where
                 return Err(format!("connect probe failed: {e}").into());
             }
             Ok(Ok(resp)) => {
-                if resp.into_inner().payload.len() != cfg.payload_size {
-                    return Err("echo self-check failed: reply payload size mismatch".into());
+                if resp.into_inner().payload != *payload {
+                    return Err(
+                        "echo self-check failed: reply payload does not match request \
+                                (byte-for-byte comparison)"
+                            .into(),
+                    );
                 }
             }
         }
@@ -77,41 +96,56 @@ where
 
     // --- Optional warmup (results discarded) ---
     if let Some(w) = cfg.warmup {
-        let _ = run_duration(&client, cfg.payload_size, cfg.concurrency, w).await;
+        let _ = run_duration(&client, &payload, cfg.concurrency, w, cfg.request_timeout).await;
     }
 
     // --- Measured run ---
     let start = Instant::now();
     let rec = match cfg.limit {
-        LoadLimit::Count(n) => run_count(&client, cfg.payload_size, cfg.concurrency, n).await,
-        LoadLimit::Duration(d) => run_duration(&client, cfg.payload_size, cfg.concurrency, d).await,
+        LoadLimit::Count(n) => {
+            run_count(&client, &payload, cfg.concurrency, n, cfg.request_timeout).await
+        }
+        LoadLimit::Duration(d) => {
+            run_duration(&client, &payload, cfg.concurrency, d, cfg.request_timeout).await
+        }
     };
     let elapsed = start.elapsed();
     Ok(BenchSummary::from_recorder(&rec, elapsed))
 }
 
 /// Issue a single echo RPC, recording latency (success) or a failure.
-async fn one_request<T>(client: &mut EchoClient<T>, payload_size: usize, rec: &mut Recorder)
-where
+///
+/// The RPC is bounded by `request_timeout`; a timed-out request is a failure so
+/// the run cannot hang on a stalled backend.
+async fn one_request<T>(
+    client: &mut EchoClient<T>,
+    payload: &[u8],
+    request_timeout: Duration,
+    rec: &mut Recorder,
+) where
     T: tonic::client::GrpcService<tonic::body::Body> + Clone + Send + 'static,
     T::Error: Into<StdError>,
     T::ResponseBody: Body<Data = Bytes> + Send + 'static,
     <T::ResponseBody as Body>::Error: Into<StdError> + Send,
     T::Future: Send,
 {
-    let payload = vec![0u8; payload_size];
     let start = Instant::now();
-    let req = tonic::Request::new(EchoRequest { payload });
-    match client.echo(req).await {
-        Ok(resp) => {
+    let req = tonic::Request::new(EchoRequest {
+        payload: payload.to_vec(),
+    });
+    match tokio::time::timeout(request_timeout, client.echo(req)).await {
+        Ok(Ok(resp)) => {
             let lat = start.elapsed();
-            if resp.into_inner().payload.len() == payload_size {
+            // Length-only check keeps per-request overhead O(1) (metrics NFR);
+            // content correctness is validated by the preflight self-check.
+            if resp.into_inner().payload.len() == payload.len() {
                 rec.record_success(lat);
             } else {
                 rec.record_failure();
             }
         }
-        Err(_) => rec.record_failure(),
+        // RPC error or timeout: both count as a failure.
+        _ => rec.record_failure(),
     }
 }
 
@@ -119,9 +153,10 @@ where
 /// shared counter, then merge the per-worker recorders.
 async fn run_count<T>(
     client: &EchoClient<T>,
-    payload_size: usize,
+    payload: &Arc<Vec<u8>>,
     concurrency: usize,
     total: u64,
+    request_timeout: Duration,
 ) -> Recorder
 where
     T: tonic::client::GrpcService<tonic::body::Body> + Clone + Send + 'static,
@@ -135,6 +170,7 @@ where
     for _ in 0..concurrency.max(1) {
         let mut c = client.clone();
         let counter = counter.clone();
+        let payload = payload.clone();
         handles.push(tokio::spawn(async move {
             let mut rec = Recorder::new();
             loop {
@@ -142,15 +178,18 @@ where
                 if n >= total {
                     break;
                 }
-                one_request(&mut c, payload_size, &mut rec).await;
+                one_request(&mut c, &payload, request_timeout, &mut rec).await;
             }
             rec
         }));
     }
     let mut merged = Recorder::new();
     for h in handles {
-        if let Ok(r) = h.await {
-            merged.merge(&r);
+        match h.await {
+            Ok(r) => merged.merge(&r),
+            // A panicked/cancelled worker is accounted as one failed request so
+            // lost work is not silently dropped from the totals.
+            Err(_) => merged.record_failure(),
         }
     }
     merged
@@ -159,9 +198,10 @@ where
 /// Run for `dur` wall-clock time across `concurrency` workers.
 async fn run_duration<T>(
     client: &EchoClient<T>,
-    payload_size: usize,
+    payload: &Arc<Vec<u8>>,
     concurrency: usize,
     dur: Duration,
+    request_timeout: Duration,
 ) -> Recorder
 where
     T: tonic::client::GrpcService<tonic::body::Body> + Clone + Send + 'static,
@@ -174,18 +214,20 @@ where
     let mut handles = Vec::new();
     for _ in 0..concurrency.max(1) {
         let mut c = client.clone();
+        let payload = payload.clone();
         handles.push(tokio::spawn(async move {
             let mut rec = Recorder::new();
             while Instant::now() < deadline {
-                one_request(&mut c, payload_size, &mut rec).await;
+                one_request(&mut c, &payload, request_timeout, &mut rec).await;
             }
             rec
         }));
     }
     let mut merged = Recorder::new();
     for h in handles {
-        if let Ok(r) = h.await {
-            merged.merge(&r);
+        match h.await {
+            Ok(r) => merged.merge(&r),
+            Err(_) => merged.record_failure(),
         }
     }
     merged

--- a/tests/bench/src/metrics.rs
+++ b/tests/bench/src/metrics.rs
@@ -1,0 +1,181 @@
+//! Latency/throughput metrics collection for the benchmark client.
+//!
+//! Latencies are recorded into an [`hdrhistogram::Histogram`] in microseconds,
+//! which is O(1) per sample with bounded memory (no per-request heap growth
+//! proportional to the request count).
+
+use std::time::Duration;
+
+use hdrhistogram::Histogram;
+
+/// Records latency samples and success/failure counts for one benchmark run.
+pub struct Recorder {
+    hist: Histogram<u64>,
+    success: u64,
+    failure: u64,
+}
+
+impl Recorder {
+    /// Create a recorder able to record latencies from 1us up to ~120s.
+    pub fn new() -> Self {
+        // 1 .. 120_000_000 us (120 s), 3 significant figures.
+        let hist =
+            Histogram::<u64>::new_with_bounds(1, 120_000_000, 3).expect("valid histogram bounds");
+        Self {
+            hist,
+            success: 0,
+            failure: 0,
+        }
+    }
+
+    /// Record a successful request with its measured latency.
+    pub fn record_success(&mut self, latency: Duration) {
+        self.success += 1;
+        // Saturate into the recordable range instead of erroring on outliers.
+        let us = latency.as_micros().min(u64::MAX as u128) as u64;
+        self.hist.saturating_record(us.max(1));
+    }
+
+    /// Record a failed request (not added to the latency histogram).
+    pub fn record_failure(&mut self) {
+        self.failure += 1;
+    }
+
+    /// Merge another recorder's samples into this one (worker aggregation).
+    pub fn merge(&mut self, other: &Recorder) {
+        self.hist.add(&other.hist).expect("compatible histograms");
+        self.success += other.success;
+        self.failure += other.failure;
+    }
+}
+
+impl Default for Recorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Aggregated, human-readable result of a benchmark run.
+#[derive(Debug, Clone)]
+pub struct BenchSummary {
+    pub total: u64,
+    pub success: u64,
+    pub failure: u64,
+    pub elapsed: Duration,
+    pub throughput_rps: f64,
+    /// Latency percentiles in microseconds (None when there were no successes).
+    pub p50_us: Option<u64>,
+    pub p90_us: Option<u64>,
+    pub p99_us: Option<u64>,
+}
+
+impl BenchSummary {
+    /// Compute a summary from a recorder and the wall-clock elapsed time.
+    pub fn from_recorder(rec: &Recorder, elapsed: Duration) -> Self {
+        let total = rec.success + rec.failure;
+        let secs = elapsed.as_secs_f64();
+        // Throughput counts only successful requests over wall-clock time.
+        let throughput_rps = if secs > 0.0 {
+            rec.success as f64 / secs
+        } else {
+            0.0
+        };
+        // Empty-sample safety: only query percentiles when we have successes.
+        let (p50, p90, p99) = if rec.success > 0 {
+            (
+                Some(rec.hist.value_at_quantile(0.50)),
+                Some(rec.hist.value_at_quantile(0.90)),
+                Some(rec.hist.value_at_quantile(0.99)),
+            )
+        } else {
+            (None, None, None)
+        };
+        Self {
+            total,
+            success: rec.success,
+            failure: rec.failure,
+            elapsed,
+            throughput_rps,
+            p50_us: p50,
+            p90_us: p90,
+            p99_us: p99,
+        }
+    }
+}
+
+fn fmt_us(v: Option<u64>) -> String {
+    match v {
+        Some(us) => format!("{:.3} ms", us as f64 / 1000.0),
+        None => "n/a".to_string(),
+    }
+}
+
+impl std::fmt::Display for BenchSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "=== Benchmark result ===")?;
+        writeln!(
+            f,
+            "requests:    {} total ({} ok, {} failed)",
+            self.total, self.success, self.failure
+        )?;
+        writeln!(f, "elapsed:     {:.3} s", self.elapsed.as_secs_f64())?;
+        writeln!(f, "throughput:  {:.1} req/s", self.throughput_rps)?;
+        writeln!(f, "latency p50: {}", fmt_us(self.p50_us))?;
+        writeln!(f, "latency p90: {}", fmt_us(self.p90_us))?;
+        write!(f, "latency p99: {}", fmt_us(self.p99_us))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summary_computes_percentiles_and_throughput() {
+        let mut rec = Recorder::new();
+        // 1000 samples of 1ms each => p50/p90/p99 all ~1ms.
+        for _ in 0..1000 {
+            rec.record_success(Duration::from_millis(1));
+        }
+        let s = BenchSummary::from_recorder(&rec, Duration::from_secs(2));
+        assert_eq!(s.total, 1000);
+        assert_eq!(s.success, 1000);
+        assert_eq!(s.failure, 0);
+        // 1000 successes over 2s => 500 req/s.
+        assert!((s.throughput_rps - 500.0).abs() < 1.0);
+        // ~1ms == 1000us within histogram precision.
+        let p50 = s.p50_us.unwrap();
+        assert!((900..=1100).contains(&p50), "p50 was {p50}");
+    }
+
+    #[test]
+    fn zero_success_is_percentile_safe() {
+        let mut rec = Recorder::new();
+        rec.record_failure();
+        rec.record_failure();
+        let s = BenchSummary::from_recorder(&rec, Duration::from_secs(1));
+        assert_eq!(s.total, 2);
+        assert_eq!(s.success, 0);
+        assert_eq!(s.failure, 2);
+        assert_eq!(s.throughput_rps, 0.0);
+        assert!(s.p50_us.is_none());
+        assert!(s.p90_us.is_none());
+        assert!(s.p99_us.is_none());
+        // Display must not panic on the empty-sample case.
+        let _ = format!("{s}");
+    }
+
+    #[test]
+    fn merge_combines_counts() {
+        let mut a = Recorder::new();
+        let mut b = Recorder::new();
+        a.record_success(Duration::from_millis(1));
+        b.record_success(Duration::from_millis(2));
+        b.record_failure();
+        a.merge(&b);
+        let s = BenchSummary::from_recorder(&a, Duration::from_secs(1));
+        assert_eq!(s.success, 2);
+        assert_eq!(s.failure, 1);
+        assert_eq!(s.total, 3);
+    }
+}

--- a/tests/bench/src/server.rs
+++ b/tests/bench/src/server.rs
@@ -23,10 +23,9 @@ where
     match transport {
         Transport::TcpTls => run_tcp_tls(addr, shutdown).await,
         Transport::Quinn => run_quinn(addr, shutdown).await,
-        other => Err(format!(
-            "server transport `{other}` is not implemented yet (added in a later phase)"
-        )
-        .into()),
+        Transport::S2nQuic => run_s2n(addr, shutdown).await,
+        Transport::Quiche => run_quiche(addr, shutdown).await,
+        Transport::Msquic => run_msquic(addr, shutdown).await,
     }
 }
 
@@ -73,6 +72,156 @@ where
         .add_service(echo_server::EchoServer::new(EchoService))
         .serve_with_incoming_shutdown(incoming, shutdown)
         .await?;
+    Ok(())
+}
+
+/// s2n-quic (HTTP/3) server. s2n has no explicit close; the serve task simply
+/// ends when `shutdown` resolves.
+async fn run_s2n<F>(addr: SocketAddr, shutdown: F) -> Result<(), BenchError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    use h3_util::s2n::s2n_quic;
+
+    let tls =
+        s2n_quic::provider::tls::rustls::server::Server::from(tls::make_server_config(&[b"h3"]));
+    let server = s2n_quic::Server::builder()
+        .with_tls(tls)
+        .map_err(|e| format!("s2n tls provider: {e}"))?
+        .with_io(addr)
+        .map_err(|e| format!("s2n io: {e}"))?
+        .start()
+        .map_err(|e| format!("s2n start: {e}"))?;
+    let local = server.local_addr()?;
+    announce(Transport::S2nQuic, local);
+
+    let acceptor = h3_util::s2n::server::H3S2nAcceptor::new(server);
+    tonic_h3::server::H3Router::new(echo_routes())
+        .serve_with_shutdown(acceptor, shutdown)
+        .await?;
+    Ok(())
+}
+
+/// quiche (HTTP/3) server. Needs cert/key FILES. Teardown: `close` + `wait_idle`.
+async fn run_quiche<F>(addr: SocketAddr, shutdown: F) -> Result<(), BenchError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    use h3_util::quiche_h3::H3QuicheServerConfig;
+
+    let (cert_path, key_path) = tls::make_test_cert_files("bench_quiche", true);
+
+    // Bind via std so we can read the real local addr before handing the socket
+    // to the acceptor; `from_std` requires the ambient Tokio runtime.
+    let std_socket = std::net::UdpSocket::bind(addr)?;
+    let local = std_socket.local_addr()?;
+    std_socket.set_nonblocking(true)?;
+    let socket = tokio::net::UdpSocket::from_std(std_socket)?;
+    announce(Transport::Quiche, local);
+
+    let config = H3QuicheServerConfig {
+        cert_path: cert_path.to_string_lossy().into_owned(),
+        key_path: key_path.to_string_lossy().into_owned(),
+        ..Default::default()
+    };
+    let acceptor = tonic_h3::quiche::H3QuicheAcceptor::new(socket, &config)?;
+    // Take a shutdown handle before the acceptor is moved into the serve task.
+    let endpoint = acceptor.endpoint();
+    tonic_h3::server::H3Router::new(echo_routes())
+        .serve_with_shutdown(acceptor, shutdown)
+        .await?;
+
+    // Drain live connection workers so the UDP port is released promptly.
+    endpoint.close(h3::error::Code::H3_NO_ERROR, b"server shutdown");
+    endpoint.wait_idle().await;
+    Ok(())
+}
+
+/// msquic (HTTP/3) server. Teardown recipe: `shutdown` -> `wait_idle` ->
+/// drop config -> drop registration.
+async fn run_msquic<F>(addr: SocketAddr, shutdown: F) -> Result<(), BenchError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    use h3_util::msquic::msquic_h3::{
+        Listener, Registration,
+        msquic::{
+            self, BufferRef, CertificateFile, Credential, CredentialConfig, CredentialFlags,
+            RegistrationConfig, Settings,
+        },
+    };
+    use h3_util::msquic::server::H3MsQuicAcceptor;
+
+    // Non-Windows: file-based self-signed credential.
+    let (cert_path, key_path) = tls::make_test_cert_files("bench_msquic", false);
+    let cred = Credential::CertificateFile(CertificateFile::new(
+        key_path.display().to_string(),
+        cert_path.display().to_string(),
+    ));
+
+    let alpn = [BufferRef::from("h3")];
+    let settings = Settings::new()
+        .set_PeerBidiStreamCount(10)
+        .set_PeerUnidiStreamCount(10)
+        .set_IdleTimeoutMs(1000);
+
+    let reg = Registration::new(
+        &RegistrationConfig::default().set_app_name("benchapp_server".to_string()),
+    )
+    .map_err(|e| format!("msquic registration: {e}"))?;
+    let config = reg
+        .open_configuration(&alpn, Some(&settings))
+        .map_err(|e| format!("msquic configuration: {e}"))?;
+    let cred_config = CredentialConfig::new()
+        .set_credential_flags(CredentialFlags::NO_CERTIFICATE_VALIDATION)
+        .set_credential(cred);
+    config
+        .load_credential(&cred_config)
+        .map_err(|e| format!("msquic load_credential: {e}"))?;
+
+    let config = Arc::new(config);
+    // Retry on ADDRESS_IN_USE (port may still be draining from a prior run).
+    let max_retry = 30;
+    let mut i = 0;
+    let listener = loop {
+        match Listener::new(&reg, config.clone(), &alpn, Some(addr)) {
+            Ok(l) => break l,
+            Err(e) => {
+                let in_use = e
+                    .try_as_status_code()
+                    .map(|c| c == msquic::StatusCode::QUIC_STATUS_ADDRESS_IN_USE)
+                    .unwrap_or(false);
+                if i < max_retry && in_use {
+                    std::thread::yield_now();
+                } else {
+                    return Err(format!("msquic listener: {e}").into());
+                }
+            }
+        }
+        i += 1;
+    };
+    let local = listener
+        .get_ref()
+        .get_local_addr()
+        .map_err(|e| format!("msquic local_addr: {e}"))?
+        .as_socket()
+        .ok_or("msquic local_addr not a socket addr")?;
+    announce(Transport::Msquic, local);
+
+    let acceptor = H3MsQuicAcceptor::new(listener);
+    let acceptor_cp = acceptor.clone();
+    tonic_h3::server::H3Router::new(echo_routes())
+        .serve_with_shutdown(acceptor, shutdown)
+        .await?;
+
+    // Teardown: stop the listener, shut down all connections, wait idle, then
+    // drop config and registration last (order matters — see msquic-h3 docs).
+    acceptor_cp.shutdown().await;
+    reg.shutdown();
+    std::mem::drop(acceptor_cp);
+    reg.wait_idle().await;
+    std::mem::drop(config);
+    std::mem::drop(reg);
     Ok(())
 }
 

--- a/tests/bench/src/server.rs
+++ b/tests/bench/src/server.rs
@@ -1,0 +1,60 @@
+//! Transport-dispatching benchmark server.
+//!
+//! Each transport arm builds the appropriate acceptor/endpoint, serves the echo
+//! service until the `shutdown` future resolves, then runs that backend's
+//! documented teardown recipe so loopback runs release their port promptly
+//! (avoiding QUIC idle-timeout hangs).
+
+use std::future::Future;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use crate::{BenchError, Transport, echo_routes, tls};
+
+/// Serve the echo service over `transport`, bound to `addr`, until `shutdown`.
+pub async fn run_server<F>(
+    transport: Transport,
+    addr: SocketAddr,
+    shutdown: F,
+) -> Result<(), BenchError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    match transport {
+        Transport::Quinn => run_quinn(addr, shutdown).await,
+        other => Err(format!(
+            "server transport `{other}` is not implemented yet (added in a later phase)"
+        )
+        .into()),
+    }
+}
+
+/// quinn (HTTP/3) server. Teardown: `close` + `wait_idle`.
+async fn run_quinn<F>(addr: SocketAddr, shutdown: F) -> Result<(), BenchError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    use quinn::crypto::rustls::QuicServerConfig;
+
+    let tls_config = Arc::new(tls::make_server_config(&[b"h3"]));
+    let server_config =
+        quinn::ServerConfig::with_crypto(Arc::new(QuicServerConfig::try_from(tls_config)?));
+    let endpoint = quinn::Endpoint::server(server_config, addr)?;
+    let local = endpoint.local_addr()?;
+    announce(Transport::Quinn, local);
+
+    let acceptor = tonic_h3::quinn::H3QuinnAcceptor::new(endpoint.clone());
+    tonic_h3::server::H3Router::new(echo_routes())
+        .serve_with_shutdown(acceptor, shutdown)
+        .await?;
+
+    endpoint.close(0u16.into(), b"server shutdown");
+    endpoint.wait_idle().await;
+    Ok(())
+}
+
+/// Log/print the actual bound address (honors FR-007 for `:0` ephemeral binds).
+pub(crate) fn announce(transport: Transport, local: SocketAddr) {
+    tracing::info!("bench-server ({transport}) listening on {local}");
+    println!("bench-server ({transport}) listening on {local}");
+}

--- a/tests/bench/src/server.rs
+++ b/tests/bench/src/server.rs
@@ -161,7 +161,6 @@ fn msquic_server_cred() -> Result<h3_util::msquic::msquic_h3::msquic::Credential
 #[cfg(target_os = "windows")]
 fn msquic_server_cred() -> Result<h3_util::msquic::msquic_h3::msquic::Credential, BenchError> {
     use h3_util::msquic::msquic_h3::msquic::{CertificateHash, Credential};
-    use std::str::FromStr;
 
     fn get_hash() -> Option<String> {
         let cmd = "Get-ChildItem Cert:\\CurrentUser\\My | Where-Object -Property FriendlyName -EQ -Value MsQuic-Test | Select-Object -ExpandProperty Thumbprint -First 1";

--- a/tests/bench/src/server.rs
+++ b/tests/bench/src/server.rs
@@ -9,7 +9,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use crate::{BenchError, Transport, echo_routes, tls};
+use crate::{BenchError, EchoService, Transport, echo_routes, echo_server, tls};
 
 /// Serve the echo service over `transport`, bound to `addr`, until `shutdown`.
 pub async fn run_server<F>(
@@ -21,6 +21,7 @@ where
     F: Future<Output = ()> + Send + 'static,
 {
     match transport {
+        Transport::TcpTls => run_tcp_tls(addr, shutdown).await,
         Transport::Quinn => run_quinn(addr, shutdown).await,
         other => Err(format!(
             "server transport `{other}` is not implemented yet (added in a later phase)"
@@ -50,6 +51,28 @@ where
 
     endpoint.close(0u16.into(), b"server shutdown");
     endpoint.wait_idle().await;
+    Ok(())
+}
+
+/// TCP + TLS (HTTP/2) baseline server via `tonic-tls`.
+async fn run_tcp_tls<F>(addr: SocketAddr, shutdown: F) -> Result<(), BenchError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    use tonic::transport::server::TcpIncoming;
+    use tonic_tls::rustls::TlsIncoming;
+
+    // gRPC over TCP negotiates HTTP/2 via ALPN "h2" (not "h3").
+    let server_config = Arc::new(tls::make_server_config(&[b"h2"]));
+    let tcp = TcpIncoming::bind(addr)?;
+    let local = tcp.local_addr()?;
+    announce(Transport::TcpTls, local);
+
+    let incoming = TlsIncoming::new(tcp, server_config);
+    tonic::transport::Server::builder()
+        .add_service(echo_server::EchoServer::new(EchoService))
+        .serve_with_incoming_shutdown(incoming, shutdown)
+        .await?;
     Ok(())
 }
 

--- a/tests/bench/src/server.rs
+++ b/tests/bench/src/server.rs
@@ -44,12 +44,14 @@ where
     announce(Transport::Quinn, local);
 
     let acceptor = tonic_h3::quinn::H3QuinnAcceptor::new(endpoint.clone());
-    tonic_h3::server::H3Router::new(echo_routes())
+    // Capture the serve result so teardown always runs, even on error.
+    let result = tonic_h3::server::H3Router::new(echo_routes())
         .serve_with_shutdown(acceptor, shutdown)
-        .await?;
+        .await;
 
     endpoint.close(0u16.into(), b"server shutdown");
     endpoint.wait_idle().await;
+    result?;
     Ok(())
 }
 
@@ -127,14 +129,73 @@ where
     let acceptor = tonic_h3::quiche::H3QuicheAcceptor::new(socket, &config)?;
     // Take a shutdown handle before the acceptor is moved into the serve task.
     let endpoint = acceptor.endpoint();
-    tonic_h3::server::H3Router::new(echo_routes())
+    // Capture the serve result so teardown always runs, even on error.
+    let result = tonic_h3::server::H3Router::new(echo_routes())
         .serve_with_shutdown(acceptor, shutdown)
-        .await?;
+        .await;
 
     // Drain live connection workers so the UDP port is released promptly.
     endpoint.close(h3::error::Code::H3_NO_ERROR, b"server shutdown");
     endpoint.wait_idle().await;
+    result?;
     Ok(())
+}
+
+/// Build the platform-appropriate self-signed msquic **server** credential.
+///
+/// On Windows, msquic's schannel TLS provider needs a certificate-store entry
+/// (referenced by hash), so we ensure a `MsQuic-Test` self-signed cert exists
+/// and pass its thumbprint. On other platforms we pass PEM cert/key files. This
+/// mirrors `tonic-h3-tests`' `get_test_cred_internal`.
+#[cfg(not(target_os = "windows"))]
+fn msquic_server_cred() -> Result<h3_util::msquic::msquic_h3::msquic::Credential, BenchError> {
+    use h3_util::msquic::msquic_h3::msquic::{CertificateFile, Credential};
+
+    let (cert_path, key_path) = tls::make_test_cert_files("bench_msquic", false);
+    Ok(Credential::CertificateFile(CertificateFile::new(
+        key_path.display().to_string(),
+        cert_path.display().to_string(),
+    )))
+}
+
+#[cfg(target_os = "windows")]
+fn msquic_server_cred() -> Result<h3_util::msquic::msquic_h3::msquic::Credential, BenchError> {
+    use h3_util::msquic::msquic_h3::msquic::{CertificateHash, Credential};
+    use std::str::FromStr;
+
+    fn get_hash() -> Option<String> {
+        let cmd = "Get-ChildItem Cert:\\CurrentUser\\My | Where-Object -Property FriendlyName -EQ -Value MsQuic-Test | Select-Object -ExpandProperty Thumbprint -First 1";
+        let output = std::process::Command::new("pwsh.exe")
+            .args(["-Command", cmd])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let mut s = String::from_utf8(output.stdout).ok()?;
+        while s.ends_with('\n') || s.ends_with('\r') {
+            s.pop();
+        }
+        if s.is_empty() { None } else { Some(s) }
+    }
+
+    fn gen_cert() {
+        let cmd = "New-SelfSignedCertificate -DnsName $env:computername,localhost -FriendlyName MsQuic-Test -KeyUsageProperty Sign -KeyUsage DigitalSignature -CertStoreLocation cert:\\CurrentUser\\My -HashAlgorithm SHA256 -Provider \"Microsoft Software Key Storage Provider\" -KeyExportPolicy Exportable";
+        let _ = std::process::Command::new("pwsh.exe")
+            .args(["-Command", cmd])
+            .output();
+    }
+
+    let hash = match get_hash() {
+        Some(h) => h,
+        None => {
+            gen_cert();
+            get_hash().ok_or("failed to create/find MsQuic-Test certificate")?
+        }
+    };
+    let cert_hash =
+        CertificateHash::from_str(&hash).map_err(|e| format!("invalid cert hash: {e}"))?;
+    Ok(Credential::CertificateHash(cert_hash))
 }
 
 /// msquic (HTTP/3) server. Teardown recipe: `shutdown` -> `wait_idle` ->
@@ -146,23 +207,21 @@ where
     use h3_util::msquic::msquic_h3::{
         Listener, Registration,
         msquic::{
-            self, BufferRef, CertificateFile, Credential, CredentialConfig, CredentialFlags,
-            RegistrationConfig, Settings,
+            self, BufferRef, CredentialConfig, CredentialFlags, RegistrationConfig, Settings,
         },
     };
     use h3_util::msquic::server::H3MsQuicAcceptor;
 
-    // Non-Windows: file-based self-signed credential.
-    let (cert_path, key_path) = tls::make_test_cert_files("bench_msquic", false);
-    let cred = Credential::CertificateFile(CertificateFile::new(
-        key_path.display().to_string(),
-        cert_path.display().to_string(),
-    ));
+    // Platform-appropriate self-signed server credential (Windows uses the cert
+    // store; other platforms use PEM files), mirroring the test harness.
+    let cred = msquic_server_cred()?;
 
     let alpn = [BufferRef::from("h3")];
+    // High stream limits so the server does not throttle benchmark concurrency
+    // (each in-flight echo RPC uses one bidirectional stream).
     let settings = Settings::new()
-        .set_PeerBidiStreamCount(10)
-        .set_PeerUnidiStreamCount(10)
+        .set_PeerBidiStreamCount(1024)
+        .set_PeerUnidiStreamCount(1024)
         .set_IdleTimeoutMs(1000);
 
     let reg = Registration::new(
@@ -210,9 +269,10 @@ where
 
     let acceptor = H3MsQuicAcceptor::new(listener);
     let acceptor_cp = acceptor.clone();
-    tonic_h3::server::H3Router::new(echo_routes())
+    // Capture the serve result so the teardown recipe always runs, even on error.
+    let result = tonic_h3::server::H3Router::new(echo_routes())
         .serve_with_shutdown(acceptor, shutdown)
-        .await?;
+        .await;
 
     // Teardown: stop the listener, shut down all connections, wait idle, then
     // drop config and registration last (order matters — see msquic-h3 docs).
@@ -222,6 +282,7 @@ where
     reg.wait_idle().await;
     std::mem::drop(config);
     std::mem::drop(reg);
+    result?;
     Ok(())
 }
 

--- a/tests/bench/src/tls.rs
+++ b/tests/bench/src/tls.rs
@@ -1,0 +1,156 @@
+//! TLS and self-signed certificate helpers for the benchmark harness.
+//!
+//! Adapted from `tonic-h3-tests/src/lib.rs` and `tonic-h3-tests/src/cert_gen.rs`.
+//! These are benchmark-only helpers: the client uses a dangerous "accept any
+//! certificate" verifier and the server uses a self-signed localhost cert. This
+//! mirrors the existing integration-test harness and is NOT suitable for
+//! production use.
+
+use std::sync::Arc;
+
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+
+/// Generate a self-signed certificate and key pair for the given SANs.
+pub fn make_test_cert(subject_alt_names: Vec<String>) -> (rcgen::Certificate, rcgen::KeyPair) {
+    let key_pair = rcgen::generate_simple_self_signed(subject_alt_names).unwrap();
+    (key_pair.cert, key_pair.signing_key)
+}
+
+/// Create cert/key PEM files on disk (needed by the quiche and msquic backends,
+/// which take certificate file paths). Files are written under the OS temp dir.
+pub fn make_test_cert_files(name: &str, regen: bool) -> (std::path::PathBuf, std::path::PathBuf) {
+    use std::io::Write;
+
+    let temp_dir = std::env::temp_dir().join("tonic_h3_bench_certs").join(name);
+
+    if regen {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+    std::fs::create_dir_all(&temp_dir).expect("failed to create temp cert dir");
+
+    let cert_path = temp_dir.join("cert.pem");
+    let key_path = temp_dir.join("key.pem");
+    if !key_path.exists() || !cert_path.exists() {
+        let (cert, key) = make_test_cert(vec!["localhost".to_string(), "127.0.0.1".to_string()]);
+
+        let mut cert_f = std::fs::File::create(&cert_path).expect("create cert file");
+        cert_f
+            .write_all(cert.pem().as_bytes())
+            .expect("write cert file");
+
+        let mut key_f = std::fs::File::create(&key_path).expect("create key file");
+        key_f
+            .write_all(key.serialize_pem().as_bytes())
+            .expect("write key file");
+    }
+    (cert_path, key_path)
+}
+
+/// Self-signed localhost cert/key as rustls DER types.
+pub fn make_test_cert_rustls() -> (CertificateDer<'static>, PrivateKeyDer<'static>) {
+    let (cert, key_pair) = make_test_cert(vec!["localhost".to_string()]);
+    let cert = CertificateDer::from(cert);
+    use rustls::pki_types::pem::PemObject;
+    let key = PrivateKeyDer::from_pem(
+        rustls::pki_types::pem::SectionKind::PrivateKey,
+        key_pair.serialize_der(),
+    )
+    .unwrap();
+    (cert, key)
+}
+
+/// Build a rustls server config with the given ALPN protocols (`b"h3"` for the
+/// QUIC backends, `b"h2"` for the TCP+TLS baseline).
+pub fn make_server_config(alpn: &[&[u8]]) -> rustls::ServerConfig {
+    let (cert, key) = make_test_cert_rustls();
+    let mut tls_config = rustls::ServerConfig::builder_with_provider(
+        rustls::crypto::aws_lc_rs::default_provider().into(),
+    )
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(vec![cert], key)
+    .unwrap();
+    tls_config.alpn_protocols = alpn.iter().map(|p| p.to_vec()).collect();
+    tls_config.max_early_data_size = u32::MAX;
+    tls_config
+}
+
+/// Build a rustls client config with a dangerous no-verification verifier and
+/// the given ALPN protocols. Benchmark-only.
+pub fn make_danger_client_config(alpn: &[&[u8]]) -> rustls::ClientConfig {
+    let mut tls_config = rustls::ClientConfig::builder_with_provider(
+        rustls::crypto::aws_lc_rs::default_provider().into(),
+    )
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .dangerous()
+    .with_custom_certificate_verifier(Arc::new(danger::NoCertificateVerification::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    )))
+    .with_no_client_auth();
+    tls_config.enable_early_data = true;
+    tls_config.alpn_protocols = alpn.iter().map(|p| p.to_vec()).collect();
+    tls_config
+}
+
+mod danger {
+    use rustls::DigitallySignedStruct;
+    use rustls::client::danger::HandshakeSignatureValid;
+    use rustls::crypto::{CryptoProvider, verify_tls12_signature, verify_tls13_signature};
+    use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+
+    #[derive(Debug)]
+    pub struct NoCertificateVerification(CryptoProvider);
+
+    impl NoCertificateVerification {
+        pub fn new(provider: CryptoProvider) -> Self {
+            Self(provider)
+        }
+    }
+
+    impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &ServerName<'_>,
+            _ocsp: &[u8],
+            _now: UnixTime,
+        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            verify_tls12_signature(
+                message,
+                cert,
+                dss,
+                &self.0.signature_verification_algorithms,
+            )
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            verify_tls13_signature(
+                message,
+                cert,
+                dss,
+                &self.0.signature_verification_algorithms,
+            )
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            self.0.signature_verification_algorithms.supported_schemes()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained gRPC **echo** benchmark harness (`tonic-h3-bench`, `publish = false`) under `tests/bench/`, so maintainers can quantitatively compare gRPC throughput and latency across every transport the repo supports. It ships two `clap`-derive binaries:

- **`bench-server`** — serves the echo service over one transport selected by `--transport`, printing its actual bound address and shutting down gracefully on SIGINT/SIGTERM.
- **`bench-client`** — a load generator (configurable concurrency, payload size, request count or duration, warmup) that reports **throughput (req/s)** and **latency percentiles (p50/p90/p99)** via `hdrhistogram`.

The same echo RPC runs over all five transports:

| `--transport` | Stack | Protocol | Maturity |
|---|---|---|---|
| `tcp-tls` | `tonic` + `tonic-tls` (rustls) | HTTP/2 / TCP | baseline |
| `quinn` | `tonic-h3` + quinn | HTTP/3 / QUIC | **production** |
| `msquic` | `tonic-h3` + msquic | HTTP/3 / QUIC | experimental |
| `s2n-quic` | `tonic-h3` + s2n-quic | HTTP/3 / QUIC | experimental |
| `quiche` | `tonic-h3` + quiche | HTTP/3 / QUIC | experimental |

## Changes

- **New crate `tests/bench/`**: `Cargo.toml`, `build.rs` (compiles `proto/echo.proto` with `tonic-prost-build`), a dedicated `echo` proto with a `bytes payload` (lets the client vary message size), the `EchoService` impl, a `Transport` clap `ValueEnum`, ALPN-parameterized rustls helpers (`h2` for TCP, `h3` for QUIC), a generic `drive_load<T>` load generator shared across HTTP/2 and HTTP/3 channels, and an `hdrhistogram`-backed metrics recorder.
- **Per-transport server/client dispatch** mirroring the acceptor/connector patterns and teardown recipes proven in `tonic-h3-tests/src/lib.rs`, so QUIC ports are released promptly instead of hanging on the ~30 s idle timeout.
- **Root `Cargo.toml`**: added `tests/bench` workspace member and workspace deps `clap`, `tonic-tls`, `hdrhistogram`.
- **Docs**: `tests/bench/README.md` (purpose, transports + maturity, build/run with runnable examples per transport, full CLI reference for both binaries, methodology, interpreting results) and a pointer from the root `README.md`.
- **`.gitignore`**: added a scoped negation `!tests/bench/src/bin/` — the repo-wide `bin` ignore rule (for .NET output) was otherwise excluding the Rust binary entry points.

## Testing

All validation performed on this branch:

- `cargo build -p tonic-h3-bench` (all transports) — and verified the committed tree builds in a **fresh `git worktree` checkout** (guards against the bin-tracking bug).
- `cargo clippy -p tonic-h3-bench --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo test -p tonic-h3-bench` — 8 unit tests pass (CLI parsing, load-limit resolution, metrics/percentile safety, concurrency validation).
- **Loopback smoke test, every transport** (server + client, confirmed `N ok, 0 failed` + metrics, prompt graceful teardown):
  - `tcp-tls`: 500/500 ok
  - `quinn`: 500/500 ok
  - `s2n-quic`: 300/300 ok (concurrency 4)
  - `msquic`: 2000/2000 ok (concurrency 32, ~9.9k req/s)
  - `quiche`: 300/300 ok (concurrency 1)
- Verified fail-fast: an unreachable server exits non-zero within the connect timeout rather than hanging.

## Notes for reviewers

- **Only the `quinn` backend is production-supported**; `msquic`/`s2n-quic`/`quiche` are experimental, consistent with the root README support matrix.
- **`quiche` is unstable under high concurrency** (a few failures + long tail at concurrency 4); documented, and it runs clean at `--concurrency 1`.
- The benchmark uses **self-signed certs + a dangerous no-verify client verifier** (loopback benchmarking only), matching the existing test harness — not a production TLS example.
- Correctness is validated **byte-for-byte in the preflight self-check**; the measured hot path uses an O(1) length check to keep the metrics-overhead NFR intact.

## Breaking Changes

None. This is a new, isolated `publish = false` crate plus additive workspace/README/`.gitignore` changes.

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)
