### PR TITLE
Bench comparison matrix, warmup support, and D2s_v5 result sets

### DIFF
--- a/docs/bench/README.md
+++ b/docs/bench/README.md
@@ -72,3 +72,11 @@ progression.
 - [Result showcase template](results-template.md)
 - [Benchmark binaries reference](../../tests/bench/README.md)
 - [Azure infrastructure reference](../../tests/infra/README.md)
+
+## Published results
+
+Curated result sets (raw artifacts stay git-ignored; only these tables are committed):
+
+- [same-zone · `Standard_D2s_v5` · 2026-07-23](results/results-same-zone-d2s_v5-20260723.md)
+- [cross-zone · `Standard_D2s_v5` · 2026-07-23](results/results-cross-zone-d2s_v5-20260723.md)
+- [cross-region · `Standard_D2s_v5` · 2026-07-23](results/results-cross-region-d2s_v5-20260723.md)

--- a/docs/bench/results/results-cross-region-d2s_v5-20260723.md
+++ b/docs/bench/results/results-cross-region-d2s_v5-20260723.md
@@ -1,0 +1,154 @@
+# Results — cross-region, `Standard_D2s_v5` (2026-07-23)
+
+Curated results from the apples-to-apples comparison matrix
+([`scenarios.yml`](../../../tests/infra/ansible/scenarios.yml)): every comparable
+transport runs the same workload points. Raw run artifacts live in the
+git-ignored `tests/infra/ansible/results/` and are **not** committed; only these
+curated tables are.
+
+Companion runs on the same hardware/software:
+[same-zone](results-same-zone-d2s_v5-20260723.md) ·
+[cross-zone](results-cross-zone-d2s_v5-20260723.md).
+
+## Setup / provenance
+
+| Field | Value |
+|-------|-------|
+| Topology | `cross-region` (client eastus2 ↔ server westus2, peered private VNets) |
+| Measured RTT | **~67 ms** (`ping` min/avg/max 65.9 / 67.0 / 70.4 ms, 0 % loss) |
+| VM SKU | `Standard_D2s_v5` (2 vCPU / 8 GiB, Accelerated Networking) |
+| OS image | Ubuntu 26.04 LTS (`ubuntu-26_04-lts:server`, glibc 2.43) |
+| Client → Server | `tonich3-client` (eastus2, 10.20.1.4) → `tonich3-server` (westus2, 10.30.1.4) |
+| `libmsquic` | 2.5.8 |
+| Repo commit | `646ca4e` (harness recorded this HEAD; the apples-to-apples matrix, warmup, and durations were uncommitted local edits at run time — pin to the landing commit for exact repro) |
+| Run id / UTC | `a9a20067b0bd5448` / `20260723T043550Z` |
+| Result | 20 / 20 scenarios, **0 failures** |
+
+**Method.** Each transport runs the identical five workload points. Throughput
+points use a fixed 15 s `duration` at steady state with a 3 s warmup (discarded),
+uniform across transports. The latency point uses a fixed count — **reduced to
+2 000 requests for cross-region** (vs 20 000 same/cross-zone) because at ~67 ms
+RTT a c=1 serialized run of 20 000 requests would take ~22 min per transport;
+2 000 still gives a stable percentile sample. gRPC echo protocol over the
+private cross-region link. `quiche` excluded (single-stream). Transports:
+`tcp-tls` (HTTP/2 baseline), `quinn` (**production** QUIC), `msquic` / `s2n-quic`
+(experimental QUIC).
+
+> **Reading these numbers:** at ~67 ms RTT the round-trip time dominates. A c=1
+> run is pinned at ~1 RTT/request (~15 req/s) for every transport, so the c=1
+> table measures the link, not the transport. The interesting signal is in the
+> **concurrent** points, where transport behavior under a high bandwidth-delay
+> product (head-of-line blocking, flow-control windows, loss recovery) diverges.
+
+---
+
+## Point 1 — latency probe (64 B, concurrency 1, count 2 000)
+
+Pure RTT floor — all transports are identical (one serialized round-trip per
+request). This row validates the link, not the transport.
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `tcp-tls`  | 15                 | 65.983   | 66.111   | 66.303   | 0      |
+| `quinn`    | 15                 | 65.983   | 66.175   | 66.367   | 0      |
+| `msquic`   | 15                 | 65.919   | 66.047   | 66.303   | 0      |
+| `s2n-quic` | 15                 | 65.983   | 66.175   | 66.367   | 0      |
+
+All four sit at the ~66 ms RTT floor, as expected.
+
+## Point 2 — small-payload throughput (64 B, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `quinn`    | 485                | 66.047   | 66.303   | 66.751   | 0      |
+| `s2n-quic` | 485                | 66.047   | 66.303   | 66.751   | 0      |
+| `msquic`   | 480                | 66.687   | 67.135   | 67.903   | 0      |
+| `tcp-tls`  | 335                | 68.607   | 131.455  | 132.095  | 0      |
+
+**QUIC wins clearly.** All three QUIC backends hold a clean ~66 ms p99 and
+~45 % higher throughput than `tcp-tls`, whose p90/p99 balloon to ~132 ms (≈ 2
+RTT) — classic HTTP/2 head-of-line blocking over a fat-pipe WAN link, where a
+single TCP connection serializes independent streams.
+
+## Point 3 — high-concurrency throughput (64 B, concurrency 128, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `msquic`   | 1 860              | 69.055   | 69.887   | 70.783   | 0      |
+| `tcp-tls`  | 1 787              | 66.559   | 85.567   | 120.639  | 0      |
+| `quinn`    | 730                | 157.055  | 263.935  | 395.775  | 0      |
+| `s2n-quic` | 561                | 199.167  | 329.983  | 397.311  | 0      |
+
+**The ordering inverts at very high concurrency.** `msquic` scales cleanly to
+1 860 req/s with a tight ~70 ms tail; `tcp-tls` also scales (1 787). But `quinn`
+and `s2n-quic` **collapse** to 730 / 561 req/s with p99 tails near 400 ms — the
+Rust userspace QUIC stacks appear flow-control / stream-window limited at 128-way
+concurrency over the high bandwidth-delay-product link (they do not reach the
+~1 900 req/s the RTT budget allows). This is the most important finding of the
+cross-region run and a concrete `quinn` scaling limit worth investigating.
+
+## Point 4 — medium-payload throughput (4 KiB, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `quinn`    | 484                | 65.791   | 66.239   | 69.119   | 0      |
+| `s2n-quic` | 484                | 65.855   | 66.943   | 68.159   | 0      |
+| `msquic`   | 476                | 67.327   | 67.967   | 68.415   | 0      |
+| `tcp-tls`  | 466                | 66.047   | 67.263   | 123.903  | 0      |
+
+At c=32 all transports are ~1 RTT/request (RTT-bound). QUIC backends hold a
+tight ~68 ms p99; `tcp-tls` matches on throughput but shows a ~124 ms p99 tail.
+
+## Point 5 — large-payload throughput (64 KiB, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `quinn`    | 479                | 66.495   | 66.943   | 68.543   | 0      |
+| `s2n-quic` | 477                | 66.431   | 67.583   | 75.583   | 0      |
+| `tcp-tls`  | 221                | 136.575  | 187.391  | 205.183  | 0      |
+| `msquic`   | 161                | 198.271  | 199.039  | 204.031  | 0      |
+
+**The biggest QUIC win.** `quinn` and `s2n-quic` sustain ~478 req/s at ~66 ms p50
+(1 RTT), while `tcp-tls` (221) and `msquic` (161) are 2–3× slower with ~2–3 RTT
+p50 — over a high-BDP link the 64 KiB response needs a large in-flight window,
+and `quinn`/`s2n-quic` handle it far better here. (Note the c=128 winner `msquic`
+is the c=32/64 KiB **loser** — its large-payload flow control lags on this link.)
+
+---
+
+## Narrative
+
+- **Headline:** At ~67 ms cross-region RTT, **HTTP/3 (QUIC) decisively beats the
+  TCP/TLS baseline** at moderate concurrency and at large payloads — the exact
+  regimes where TCP head-of-line blocking hurts. `tcp-tls` p99 repeatedly
+  inflates to ~2 RTT (~132 ms) while the QUIC backends hold ~1 RTT.
+- **Where production `quinn` wins:** 64 B / c=32 (+45 % vs baseline, 2× tighter
+  tail) and 64 KiB / c=32 (2× the baseline throughput). This is the strongest
+  case for `tonic-h3` over `tonic`+TLS in the whole sweep.
+- **Where `quinn` loses — a real scaling limit:** at 64 B / c=128 both `quinn`
+  and `s2n-quic` collapse (730 / 561 req/s, ~400 ms p99) while `msquic` and
+  `tcp-tls` scale to ~1 800. The userspace Rust QUIC stacks appear flow-control /
+  stream-window bound at very high concurrency over a high-BDP link — a concrete
+  follow-up for the production backend.
+- **vs same/cross-zone:** In-zone/in-region (sub-ms RTT) the baseline led almost
+  everywhere; adding real WAN RTT flips the result — QUIC's loss/HoL-independent
+  streams are worth 45–100 % here. RTT, not raw CPU, is the deciding variable.
+- **Caveats:** 2 vCPU; the c=1 latency point used count 2 000 (not 20 000) for
+  runtime — it only measures the RTT floor anyway. `msquic` / `s2n-quic` are
+  experimental. `quiche` excluded (single-stream). All 20 scenarios `failed = 0`.
+
+## Reproducing
+
+```bash
+tests/infra/scripts/deploy.sh cross-region         # eastus2 (client) + westus2 (server)
+cd tests/infra/ansible
+python3 inventory.py --resource-group rg-tonich3-bench-cross-region
+# latency point reduced to count 2000 for the ~67ms RTT link:
+ansible-playbook run-bench.yml -e @scenarios.yml \
+  -e '{"scenarios":[ ...same as scenarios.yml, but the c=1 points use count: 2000 ]}' \
+  -e topology=cross-region -e vm_size=Standard_D2s_v5 -e region=eastus2-westus2 \
+  -e bench_port=50051 -e bench_libmsquic_version=2.5.8
+```
+
+Each cell traces back to a `result-*.json` + `*.meta.json` pair in the
+git-ignored results dir (run id `a9a20067b0bd5448`).

--- a/docs/bench/results/results-cross-zone-d2s_v5-20260723.md
+++ b/docs/bench/results/results-cross-zone-d2s_v5-20260723.md
@@ -1,0 +1,139 @@
+# Results — cross-zone, `Standard_D2s_v5` (2026-07-23)
+
+Curated results from the apples-to-apples comparison matrix
+([`scenarios.yml`](../../../tests/infra/ansible/scenarios.yml)): every comparable
+transport runs the exact same workload points. Raw run artifacts live in the
+git-ignored `tests/infra/ansible/results/` and are **not** committed; only these
+curated tables are.
+
+For the same hardware/software on a **same-zone** link, see
+[results-same-zone-d2s_v5-20260723.md](results-same-zone-d2s_v5-20260723.md).
+
+## Setup / provenance
+
+| Field | Value |
+|-------|-------|
+| Topology | `cross-zone` (client zone 1, server zone 2, same region, peered private VNet) |
+| VM SKU | `Standard_D2s_v5` (2 vCPU / 8 GiB, Accelerated Networking) |
+| OS image | Ubuntu 26.04 LTS (`ubuntu-26_04-lts:server`, glibc 2.43) |
+| Region | `eastus2` |
+| Client → Server | `tonich3-client` (10.20.1.5, zone 1) → `tonich3-server` (10.20.1.4, zone 2) |
+| `libmsquic` | 2.5.8 |
+| Repo commit | `646ca4e` (harness recorded this HEAD; the apples-to-apples matrix, 15 s durations, and 3 s warmup were uncommitted local edits at run time — pin to the commit that lands them for an exact repro) |
+| Run id / UTC | `97342d50ad0a978c` / `20260723T041232Z` |
+| Result | 20 / 20 scenarios, **0 failures** |
+
+**Method.** Each transport runs the identical five workload points. Throughput
+points use a fixed 15 s `duration` at steady state with a 3 s warmup (discarded)
+applied uniformly to every transport; the latency point uses a fixed count of
+20 000 requests (no warmup) so per-request percentiles sample every request.
+gRPC echo protocol over the private inter-zone link. `quiche` is excluded
+(single-stream only). Transports: `tcp-tls` (tonic + tonic-tls over TCP/TLS,
+HTTP/2 baseline), `quinn` (tonic-h3 over QUIC, **production**), `msquic` and
+`s2n-quic` (tonic-h3 over QUIC, experimental).
+
+---
+
+## Point 1 — latency probe (64 B, concurrency 1, count 20 000)
+
+Serialized round-trips; isolates per-request latency (no queuing). The
+inter-zone hop adds ~0.1 ms to every transport's p50 vs same-zone.
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `tcp-tls`  | 3 371              | 0.295    | 0.326    | 0.354    | 0      |
+| `quinn`    | 3 146              | 0.315    | 0.345    | 0.376    | 0      |
+| `s2n-quic` | 2 750              | 0.360    | 0.392    | 0.425    | 0      |
+| `msquic`   | 1 994              | 0.499    | 0.569    | 0.626    | 0      |
+
+`tcp-tls` and `quinn` are effectively tied (within ~7 %); `msquic` is the
+slowest single-request path again.
+
+## Point 2 — small-payload throughput (64 B, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `s2n-quic` | 47 159             | 0.663    | 0.815    | 1.074    | 0      |
+| `tcp-tls`  | 44 938             | 0.704    | 0.840    | 0.992    | 0      |
+| `quinn`    | 43 407             | 0.732    | 0.891    | 1.039    | 0      |
+| `msquic`   | 26 894             | 1.172    | 1.382    | 1.951    | 0      |
+
+`s2n-quic` leads; `quinn` (production) is now within ~3 % of the `tcp-tls`
+baseline — noticeably closer than same-zone (~12 % gap there).
+
+## Point 3 — high-concurrency throughput (64 B, concurrency 128, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `tcp-tls`  | 66 644             | 1.842    | 2.497    | 3.193    | 0      |
+| `quinn`    | 52 141             | 2.249    | 3.845    | 5.627    | 0      |
+| `s2n-quic` | 50 969             | 2.407    | 3.651    | 5.287    | 0      |
+| `msquic`   | 36 737             | 3.515    | 4.071    | 4.583    | 0      |
+
+`tcp-tls` again leads clearly at 128-way concurrency; `quinn` edges past
+`s2n-quic` here. `msquic` keeps the tightest p90→p99 tail of the QUIC backends.
+
+## Point 4 — medium-payload throughput (4 KiB, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `s2n-quic` | 27 115             | 1.147    | 1.489    | 1.858    | 0      |
+| `quinn`    | 26 954             | 1.187    | 1.452    | 1.699    | 0      |
+| `tcp-tls`  | 25 933             | 1.209    | 1.606    | 1.927    | 0      |
+| `msquic`   | 18 623             | 1.725    | 1.914    | 2.123    | 0      |
+
+At 4 KiB the QUIC backends `s2n-quic` and **`quinn` both beat the `tcp-tls`
+baseline** (quinn also posts the lowest p99) — the first regime where production
+QUIC is ahead.
+
+## Point 5 — large-payload throughput (64 KiB, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `tcp-tls`  | 6 504              | 4.811    | 6.379    | 7.967    | 0      |
+| `msquic`   | 4 006              | 7.943    | 9.935    | 11.471   | 0      |
+| `s2n-quic` | 3 150              | 11.263   | 12.903   | 14.087   | 0      |
+| `quinn`    | 2 839              | 12.239   | 14.711   | 16.591   | 0      |
+
+Same as same-zone: `tcp-tls` dominates 64 KiB (~1.6× the best QUIC backend),
+`msquic` is the fastest QUIC backend, `quinn` last — userspace QUIC is
+CPU/flow-control bound at large messages on this 2-vCPU SKU.
+
+---
+
+## Narrative
+
+- **Headline:** Moving from same-zone to cross-zone (adding inter-zone RTT but no
+  loss) **narrows the gap between production `quinn` and the `tcp-tls` baseline**
+  on small/medium payloads, and at 4 KiB the QUIC backends (`s2n-quic`, `quinn`)
+  overtake the baseline outright.
+- **vs same-zone:** Latency rose ~0.1 ms p50 across the board (the zone hop).
+  Small-payload throughput barely moved for `tcp-tls`/`quinn`/`s2n-quic` (this
+  link is still not the bottleneck), while `quinn` closed from ~12 % behind the
+  baseline (same-zone) to ~3 % (cross-zone).
+- **Baseline vs QUIC:** `tcp-tls` still wins c=1 latency, c=128 throughput, and
+  64 KiB payloads. QUIC wins at 4 KiB / c=32 and ties at 64 B / c=32.
+- **Among QUIC backends:** `s2n-quic` leads small/medium throughput, `quinn` is
+  the lowest-latency QUIC backend and best at 4 KiB p99, `msquic` trails on
+  small-RPC but leads QUIC at 64 KiB.
+- **Where QUIC still does not win:** high concurrency (c=128) and large payloads
+  remain baseline territory on 2 vCPU — both are CPU-bound regimes for userspace
+  QUIC. A cross-**region** run (higher RTT, possible loss) and a larger SKU are
+  the natural next experiments to see HTTP/3's loss-recovery advantage emerge.
+- **Caveats:** 2 vCPU is CPU-bound for userspace QUIC at 64 KiB. `msquic` and
+  `s2n-quic` are experimental. `quiche` excluded (single-stream). All 20
+  scenarios completed with `failed = 0`.
+
+## Reproducing
+
+```bash
+tests/infra/scripts/deploy.sh cross-zone           # Ubuntu 26.04, D2s_v5, eastus2 z1/z2
+cd tests/infra/ansible
+python3 inventory.py --resource-group rg-tonich3-bench-cross-zone
+ansible-playbook run-bench.yml -e @scenarios.yml \
+  -e topology=cross-zone -e vm_size=Standard_D2s_v5 -e region=eastus2 \
+  -e bench_port=50051 -e bench_libmsquic_version=2.5.8
+```
+
+Each cell traces back to a `result-*.json` + `*.meta.json` pair in the
+git-ignored results dir (run id `97342d50ad0a978c`).

--- a/docs/bench/results/results-same-zone-d2s_v5-20260723.md
+++ b/docs/bench/results/results-same-zone-d2s_v5-20260723.md
@@ -1,0 +1,152 @@
+# Results — same-zone, `Standard_D2s_v5` (2026-07-23)
+
+Curated results from the apples-to-apples comparison matrix
+([`scenarios.yml`](../../../tests/infra/ansible/scenarios.yml)): every comparable
+transport runs the exact same workload points. Raw run artifacts live in the
+git-ignored `tests/infra/ansible/results/` and are **not** committed; only these
+curated tables are.
+
+## Setup / provenance
+
+| Field | Value |
+|-------|-------|
+| Topology | `same-zone` (both VMs in eastus2, zone 1, peered private VNet) |
+| VM SKU | `Standard_D2s_v5` (2 vCPU / 8 GiB, Accelerated Networking) |
+| OS image | Ubuntu 26.04 LTS (`ubuntu-26_04-lts:server`, glibc 2.43) |
+| Region | `eastus2` |
+| Client → Server | `tonich3-client` (10.20.1.4) → `tonich3-server` (10.20.1.5) |
+| `libmsquic` | 2.5.8 |
+| Repo commit | `646ca4e` (harness recorded this HEAD; the apples-to-apples matrix, 15 s durations, and 3 s warmup were uncommitted local edits at run time — pin to the commit that lands them for an exact repro) |
+| Run id / UTC | `2a4b0609f0fb1c40` / `20260723T034733Z` |
+| Result | 20 / 20 scenarios, **0 failures** |
+
+**Method.** Each transport runs the identical five workload points. Throughput
+points use a fixed 15 s `duration` at steady state with a 3 s warmup (discarded)
+applied uniformly to every transport; the latency point uses a fixed count of
+20 000 requests (no warmup) so per-request percentiles sample every request.
+gRPC echo protocol over the private network. `quiche` is excluded (single-stream
+only — cannot run the shared `concurrency ≥ 32` points).
+
+Transports: `tcp-tls` (tonic + tonic-tls over TCP/TLS, HTTP/2 — the non-QUIC
+baseline), `quinn` (tonic-h3 over QUIC, **production**), `msquic` and `s2n-quic`
+(tonic-h3 over QUIC, experimental). Throughput is `throughput_rps` (higher is
+better); latencies are per-request round-trip milliseconds.
+
+---
+
+## Point 1 — latency probe (64 B, concurrency 1, count 20 000)
+
+Serialized round-trips; isolates per-request latency (no queuing). Best signal
+for p50/tail.
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `tcp-tls`  | 5 529              | 0.176    | 0.198    | 0.241    | 0      |
+| `quinn`    | 4 842              | 0.203    | 0.224    | 0.266    | 0      |
+| `s2n-quic` | 4 520              | 0.217    | 0.238    | 0.271    | 0      |
+| `msquic`   | 2 905              | 0.330    | 0.425    | 0.507    | 0      |
+
+Lowest latency is `tcp-tls`; `quinn` and `s2n-quic` follow within ~15 %. `msquic`
+has the highest single-request latency (~1.6× the baseline p50).
+
+## Point 2 — small-payload throughput (64 B, concurrency 32, 15 s)
+
+The primary small-RPC throughput comparison.
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `s2n-quic` | 44 575             | 0.711    | 0.859    | 1.026    | 0      |
+| `tcp-tls`  | 43 279             | 0.721    | 0.921    | 1.180    | 0      |
+| `quinn`    | 38 237             | 0.821    | 1.076    | 1.533    | 0      |
+| `msquic`   | 23 963             | 1.313    | 1.658    | 2.031    | 0      |
+
+`s2n-quic` narrowly edges the `tcp-tls` baseline and even posts a lower p99;
+`quinn` trails by ~12 %; `msquic` is ~45 % below the leaders.
+
+## Point 3 — high-concurrency throughput (64 B, concurrency 128, 15 s)
+
+Stresses stream multiplexing / scheduling under heavier in-flight load.
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `tcp-tls`  | 61 694             | 1.991    | 2.727    | 3.381    | 0      |
+| `s2n-quic` | 49 477             | 2.463    | 3.751    | 5.343    | 0      |
+| `quinn`    | 44 959             | 2.633    | 4.419    | 6.327    | 0      |
+| `msquic`   | 33 786             | 3.783    | 4.523    | 5.555    | 0      |
+
+At 128-way concurrency the `tcp-tls` baseline pulls clearly ahead (~25 % over the
+best QUIC backend). The QUIC backends also show wider p99 tails here, with
+`quinn` exhibiting the largest p90→p99 spread.
+
+## Point 4 — medium-payload throughput (4 KiB, concurrency 32, 15 s)
+
+Representative message size; balances framing overhead vs. bandwidth.
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `s2n-quic` | 26 407             | 1.197    | 1.445    | 1.783    | 0      |
+| `tcp-tls`  | 25 414             | 1.237    | 1.613    | 1.951    | 0      |
+| `quinn`    | 23 523             | 1.355    | 1.739    | 2.171    | 0      |
+| `msquic`   | 18 144             | 1.747    | 2.033    | 2.347    | 0      |
+
+Ordering matches the small-payload point: `s2n-quic` ≈ `tcp-tls` > `quinn` >
+`msquic`, all bunched within ~30 %.
+
+## Point 5 — large-payload throughput (64 KiB, concurrency 32, 15 s)
+
+Bandwidth-bound regime; surfaces per-transport copy / flow-control overhead.
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `tcp-tls`  | 6 860              | 4.555    | 6.131    | 7.751    | 0      |
+| `msquic`   | 3 888              | 8.187    | 10.199   | 11.815   | 0      |
+| `s2n-quic` | 3 337              | 10.743   | 12.455   | 13.559   | 0      |
+| `quinn`    | 2 786              | 12.431   | 14.863   | 17.055   | 0      |
+
+The `tcp-tls` baseline dominates at 64 KiB (~1.8× the best QUIC backend). Among
+the QUIC backends the order inverts versus small payloads: `msquic` leads,
+`quinn` (production) is last — the userspace QUIC flow-control / copy path is the
+bottleneck at large messages on this 2-vCPU SKU.
+
+---
+
+## Narrative
+
+- **Headline:** On a 2-vCPU same-zone pair the TCP/TLS (HTTP/2) baseline is the
+  strongest or tied-strongest at every point except moderate small-payload
+  concurrency, where `s2n-quic` narrowly leads. The **production `quinn`** backend
+  tracks the leaders within ~12–15 % on small payloads but falls well behind on
+  64 KiB messages.
+- **Baseline vs QUIC:** `tcp-tls` wins outright at c=1 latency, c=128 throughput,
+  and 64 KiB payloads; it is essentially tied with `s2n-quic` at c=32 (64 B / 4 KiB).
+  No QUIC backend beats the baseline on tail latency at high concurrency.
+- **Among QUIC backends:** `s2n-quic` is the small-payload throughput leader;
+  `quinn` is a close second and the lowest-latency QUIC backend at c=1; `msquic`
+  trails on small-RPC but is the fastest QUIC backend at 64 KiB.
+- **Where QUIC does not yet win:** every regime here is a low-RTT, lossless
+  same-zone link — precisely where HTTP/3's loss-recovery / head-of-line-blocking
+  advantages do **not** manifest. Expect the QUIC backends to close (or reverse)
+  the gap under cross-zone / cross-region RTT and packet loss; those topologies
+  are the motivating follow-up.
+- **Caveats:** 2 vCPU is easily CPU-bound for userspace QUIC at 64 KiB — a larger
+  SKU (`D4s_v5` / `D8s_v5`) may change the large-payload ordering. `msquic` and
+  `s2n-quic` are experimental backends. `quiche` was excluded (single-stream).
+  All 20 scenarios completed with `failed = 0` and `ok` equal to the requested
+  count (or full 15 s duration), so every row is a valid data point.
+
+## Reproducing
+
+Deploy the same topology and re-run the recorded matrix (see the
+[run procedure](../run-procedure.md)):
+
+```bash
+tests/infra/scripts/deploy.sh same-zone            # Ubuntu 26.04, D2s_v5, eastus2
+cd tests/infra/ansible
+python3 inventory.py --resource-group rg-tonich3-bench-same-zone
+ansible-playbook run-bench.yml -e @scenarios.yml \
+  -e topology=same-zone -e vm_size=Standard_D2s_v5 -e region=eastus2 \
+  -e bench_port=50051 -e bench_libmsquic_version=2.5.8
+```
+
+Each cell traces back to a `result-*.json` + `*.meta.json` pair in the
+git-ignored results dir (run id `2a4b0609f0fb1c40`).

--- a/tests/infra/ansible/run-bench.yml
+++ b/tests/infra/ansible/run-bench.yml
@@ -54,6 +54,10 @@
     # How long to wait for server readiness / shutdown (seconds).
     bench_ready_timeout: 30
     bench_stop_timeout: 20
+    # Default warmup (seconds, results discarded) applied to duration-based
+    # throughput scenarios; count-based latency scenarios get none unless a
+    # scenario sets its own `warmup`. Set to 0 to disable warmup by default.
+    bench_warmup_default: 3
     # libmsquic version deployed on the VMs (recorded in each metadata sidecar
     # for reproducibility). Pass the same value used with deploy-bench.yml.
     bench_libmsquic_version: unknown
@@ -83,6 +87,7 @@
           - (item.count is defined) != (item.duration is defined)
           - (item.count is not defined) or ((item.count | int) > 0)
           - (item.duration is not defined) or ((item.duration | int) > 0)
+          - (item.warmup is not defined) or ((item.warmup | int) >= 0)
         quiet: true
         fail_msg: >-
           Invalid scenario {{ item }}: need a known transport, payload_size >= 0,

--- a/tests/infra/ansible/scenarios.example.yml
+++ b/tests/infra/ansible/scenarios.example.yml
@@ -1,0 +1,38 @@
+---
+# Example / alternate benchmark scenario matrix for run-bench.yml (mixed sweep).
+#
+# This is the previous mixed matrix, kept as a reference example. The default
+# comparison matrix now lives in scenarios.yml (apples-to-apples: every
+# comparable transport runs the same workload points). Pass THIS file instead
+# when you want the older mixed sweep:
+#   ansible-playbook run-bench.yml -e @scenarios.example.yml \
+#     -e topology=... -e vm_size=... -e region=... -e bench_port=50051
+#
+# Each scenario is a dict:
+#   transport     : tcp-tls | quinn | msquic | s2n-quic | quiche
+#   payload_size  : echo payload in bytes
+#   concurrency   : in-flight workers (quiche is auto-forced to 1)
+#   count | duration : request budget (fixed count) OR wall-clock seconds (exactly one)
+#   port          : (optional) data-plane port override; defaults to bench_port
+#
+# See docs/bench/scenario-matrix.md for the design rationale.
+scenarios:
+  # --- Baseline vs production QUIC, small payload, concurrency sweep ---
+  - { transport: tcp-tls, payload_size: 64,    concurrency: 1,   count: 20000 }
+  - { transport: tcp-tls, payload_size: 64,    concurrency: 32,  count: 50000 }
+  - { transport: quinn,   payload_size: 64,    concurrency: 1,   count: 20000 }
+  - { transport: quinn,   payload_size: 64,    concurrency: 32,  count: 50000 }
+
+  # --- Payload-size sweep on the production backends ---
+  - { transport: tcp-tls, payload_size: 4096,  concurrency: 32,  count: 50000 }
+  - { transport: quinn,   payload_size: 4096,  concurrency: 32,  count: 50000 }
+  - { transport: quinn,   payload_size: 65536, concurrency: 32,  count: 20000 }
+
+  # --- Experimental backends (evaluation only) ---
+  - { transport: msquic,   payload_size: 64,   concurrency: 16,  count: 20000 }
+  - { transport: s2n-quic, payload_size: 64,   concurrency: 16,  count: 20000 }
+  # quiche: concurrency is forced to 1 by the playbook regardless of this value.
+  - { transport: quiche,   payload_size: 64,   concurrency: 1,   count: 10000 }
+
+  # --- Duration-based steady-state sample (demonstrates the duration budget) ---
+  - { transport: quinn,   payload_size: 64,    concurrency: 32,  duration: 30 }

--- a/tests/infra/ansible/scenarios.yml
+++ b/tests/infra/ansible/scenarios.yml
@@ -1,34 +1,79 @@
 ---
-# Example benchmark scenario matrix for run-bench.yml.
+# Apples-to-apples benchmark comparison matrix for run-bench.yml.
+#
+# Every comparable transport runs the EXACT same set of workload points so the
+# results are directly comparable transport-by-transport. Five workload points
+# (a latency probe, two concurrency levels at the small RPC payload, plus a
+# medium and a large payload throughput point) are applied identically to each
+# of the four comparable transports:
+#
+#   tcp-tls  - tonic + tonic-tls over TCP/TLS (HTTP/2). The non-QUIC baseline.
+#   quinn    - tonic-h3 over QUIC (the production-supported backend).
+#   msquic   - tonic-h3 over QUIC (experimental backend).
+#   s2n-quic - tonic-h3 over QUIC (experimental backend).
+#
+# quiche is intentionally EXCLUDED: it stalls above concurrency 1, so it cannot
+# run the shared concurrency>=32 points and would not be an apples-to-apples
+# comparison. Evaluate it separately with a concurrency-1 matrix if needed.
+#
+# Budget choice: throughput points use a fixed wall-clock `duration` (steady
+# state, identical measurement window for every transport); the latency point
+# uses a fixed `count` so per-request latency percentiles are measured over the
+# same number of samples for every transport.
+#
+# Warmup: duration-based scenarios get a default warmup (bench_warmup_default,
+# 3s; results discarded) applied identically to every transport, so cold-start
+# handshake/ramp effects are excluded from the measured window. Count-based
+# latency scenarios get no warmup by default. Override per scenario with a
+# `warmup` field (seconds), or globally with -e bench_warmup_default=<n>.
 #
 # Pass this file to override the small built-in default matrix:
-#   ansible-playbook run-bench.yml -e @scenarios.yml -e topology=... -e vm_size=...
+#   ansible-playbook run-bench.yml -e @scenarios.yml \
+#     -e topology=same-zone -e vm_size=Standard_D2s_v5 -e region=eastus2 \
+#     -e bench_port=50051 -e bench_libmsquic_version=2.5.8
 #
 # Each scenario is a dict:
-#   transport     : tcp-tls | quinn | msquic | s2n-quic | quiche
+#   transport     : tcp-tls | quinn | msquic | s2n-quic
 #   payload_size  : echo payload in bytes
-#   concurrency   : in-flight workers (quiche is auto-forced to 1)
-#   count | duration : request budget (fixed count) OR wall-clock seconds (exactly one)
+#   concurrency   : in-flight workers
+#   count | duration : request budget (fixed count) OR wall-clock seconds (one)
+#   warmup        : (optional) warmup seconds, results discarded; defaults to
+#                   bench_warmup_default (3s) for duration runs, 0 for count runs
 #   port          : (optional) data-plane port override; defaults to bench_port
 #
 # See docs/bench/scenario-matrix.md for the design rationale.
 scenarios:
-  # --- Baseline vs production QUIC, small payload, concurrency sweep ---
-  - { transport: tcp-tls, payload_size: 64,    concurrency: 1,   count: 20000 }
-  - { transport: tcp-tls, payload_size: 64,    concurrency: 32,  count: 50000 }
-  - { transport: quinn,   payload_size: 64,    concurrency: 1,   count: 20000 }
-  - { transport: quinn,   payload_size: 64,    concurrency: 32,  count: 50000 }
+  # === Point 1: latency probe - small payload, single in-flight request ======
+  # Serialized round-trips; isolates per-request latency (no queuing).
+  - { transport: tcp-tls,  payload_size: 64,    concurrency: 1,   count: 20000 }
+  - { transport: quinn,    payload_size: 64,    concurrency: 1,   count: 20000 }
+  - { transport: msquic,   payload_size: 64,    concurrency: 1,   count: 20000 }
+  - { transport: s2n-quic, payload_size: 64,    concurrency: 1,   count: 20000 }
 
-  # --- Payload-size sweep on the production backends ---
-  - { transport: tcp-tls, payload_size: 4096,  concurrency: 32,  count: 50000 }
-  - { transport: quinn,   payload_size: 4096,  concurrency: 32,  count: 50000 }
-  - { transport: quinn,   payload_size: 65536, concurrency: 32,  count: 20000 }
+  # === Point 2: throughput - small payload, moderate concurrency (c=32) ======
+  # The primary small-RPC throughput comparison point.
+  - { transport: tcp-tls,  payload_size: 64,    concurrency: 32,  duration: 15 }
+  - { transport: quinn,    payload_size: 64,    concurrency: 32,  duration: 15 }
+  - { transport: msquic,   payload_size: 64,    concurrency: 32,  duration: 15 }
+  - { transport: s2n-quic, payload_size: 64,    concurrency: 32,  duration: 15 }
 
-  # --- Experimental backends (evaluation only) ---
-  - { transport: msquic,   payload_size: 64,   concurrency: 16,  count: 20000 }
-  - { transport: s2n-quic, payload_size: 64,   concurrency: 16,  count: 20000 }
-  # quiche: concurrency is forced to 1 by the playbook regardless of this value.
-  - { transport: quiche,   payload_size: 64,   concurrency: 1,   count: 10000 }
+  # === Point 3: throughput - small payload, high concurrency (c=128) =========
+  # Stresses stream multiplexing / scheduling under heavier in-flight load.
+  - { transport: tcp-tls,  payload_size: 64,    concurrency: 128, duration: 15 }
+  - { transport: quinn,    payload_size: 64,    concurrency: 128, duration: 15 }
+  - { transport: msquic,   payload_size: 64,    concurrency: 128, duration: 15 }
+  - { transport: s2n-quic, payload_size: 64,    concurrency: 128, duration: 15 }
 
-  # --- Duration-based steady-state sample (demonstrates the duration budget) ---
-  - { transport: quinn,   payload_size: 64,    concurrency: 32,  duration: 30 }
+  # === Point 4: throughput - medium payload (4 KiB), moderate concurrency ====
+  # Representative message size; balances framing overhead vs. bandwidth.
+  - { transport: tcp-tls,  payload_size: 4096,  concurrency: 32,  duration: 15 }
+  - { transport: quinn,    payload_size: 4096,  concurrency: 32,  duration: 15 }
+  - { transport: msquic,   payload_size: 4096,  concurrency: 32,  duration: 15 }
+  - { transport: s2n-quic, payload_size: 4096,  concurrency: 32,  duration: 15 }
+
+  # === Point 5: throughput - large payload (64 KiB), moderate concurrency ====
+  # Bandwidth-bound regime; surfaces per-transport copy/flow-control overhead.
+  - { transport: tcp-tls,  payload_size: 65536, concurrency: 32,  duration: 15 }
+  - { transport: quinn,    payload_size: 65536, concurrency: 32,  duration: 15 }
+  - { transport: msquic,   payload_size: 65536, concurrency: 32,  duration: 15 }
+  - { transport: s2n-quic, payload_size: 65536, concurrency: 32,  duration: 15 }

--- a/tests/infra/ansible/tasks/run-scenario.yml
+++ b/tests/infra/ansible/tasks/run-scenario.yml
@@ -16,6 +16,12 @@
     # Exactly one of count/duration is present per scenario (validated upfront).
     budget_args: "{{ ('--count ' ~ scenario.count) if scenario.count is defined else ('--duration ' ~ scenario.duration) }}"
     budget_label: "{{ ('n' ~ scenario.count) if scenario.count is defined else ('d' ~ scenario.duration ~ 's') }}"
+    # Warmup seconds (results discarded): an explicit per-scenario `warmup`
+    # override wins; otherwise duration-based throughput runs get the default
+    # warmup and count-based latency runs get none (every request is measured).
+    # Applied identically to every transport, so comparisons stay apples-to-apples.
+    warmup: "{{ scenario.warmup if scenario.warmup is defined else (bench_warmup_default if scenario.duration is defined else 0) }}"
+    warmup_args: "{{ ('--warmup ' ~ (warmup | int)) if (warmup | int) > 0 else '' }}"
     # Server private IP (loopback 127.0.0.1 in the local dry-run inventory).
     server_ip: "{{ hostvars['server'].private_ip }}"
     # A zero-padded scenario index guarantees uniqueness within one invocation;
@@ -45,6 +51,7 @@
           concurrency: "{{ eff_conc | int }}"
           requested_concurrency: "{{ scenario.concurrency }}"
           budget: "{{ ('count=' ~ scenario.count) if scenario.count is defined else ('duration=' ~ scenario.duration ~ 's') }}"
+          warmup: "{{ warmup | int }}"
           port: "{{ port | int }}"
           libmsquic_version: "{{ bench_libmsquic_version | default('unknown') }}"
           git_commit: "{{ git_commit }}"
@@ -85,6 +92,7 @@
           --payload-size {{ scenario.payload_size }}
           --concurrency {{ eff_conc }}
           {{ budget_args }}
+          {{ warmup_args }}
           --format json
           > {{ remote_result }} 2> {{ remote_client_err }}
         executable: /bin/bash


### PR DESCRIPTION
## Summary

Rework the Azure benchmark scenario matrix and harness for **fair,
apples-to-apples transport comparison**, add optional **warmup** support, and
record the first cross-topology result sets (same-zone, cross-zone,
cross-region) on `Standard_D2s_v5`.

## Harness & scenarios

- **`scenarios.yml` — apples-to-apples matrix.** The same five workload points
  are applied *identically* to every comparable transport (`tcp-tls`, `quinn`,
  `msquic`, `s2n-quic`):
  1. latency probe — 64 B, c=1, count 20 000
  2. small-payload throughput — 64 B, c=32, 15 s
  3. high-concurrency throughput — 64 B, c=128, 15 s
  4. medium payload — 4 KiB, c=32, 15 s
  5. large payload — 64 KiB, c=32, 15 s

  `quiche` is **excluded** (single-stream; can't run the shared c≥32 points).
  Throughput points use a fixed `duration`; the latency point uses a fixed
  `count`.
- **`scenarios.example.yml`** — the previous mixed sweep, kept as a reference
  example.
- **Warmup support** (`run-bench.yml` + `tasks/run-scenario.yml`): a
  `bench_warmup_default` (3 s, results discarded) is applied to duration-based
  throughput scenarios and recorded in each metadata sidecar; count-based
  latency scenarios get none unless a scenario sets its own `warmup`. Applied
  uniformly across transports so comparisons stay fair. Preflight validation
  rejects a negative `warmup`.

## Results

`docs/bench/results/` — three curated result sets, each **20/20 scenarios, 0
failures** (`Standard_D2s_v5`, Ubuntu 26.04, gRPC echo over the private link):

- `results-same-zone-d2s_v5-20260723.md`
- `results-cross-zone-d2s_v5-20260723.md`
- `results-cross-region-d2s_v5-20260723.md`

Only curated tables are committed; raw run artifacts stay git-ignored. Linked
from `docs/bench/README.md`.

**Headline finding:** in-zone/in-region (sub-ms RTT) the TCP/TLS HTTP/2 baseline
leads almost everywhere; at ~67 ms cross-region RTT **HTTP/3 (QUIC) decisively
wins** at moderate concurrency and large payloads (production `quinn` ~2× the
baseline at 64 KiB / c=32, holding 1-RTT latency where TCP needs 2–3). One
concrete follow-up surfaced: `quinn`/`s2n-quic` show a scaling limit at 64 B /
c=128 cross-region (they collapse where `msquic`/`tcp-tls` scale cleanly).

## Validation

- `ansible-playbook run-bench.yml --syntax-check` passes.
- Warmup wiring verified via loopback dry-run (metadata records `warmup`, the
  measured `elapsed_s` excludes the warmup window).
- All doc relative links verified to resolve.
- Every result row has `failed = 0` with `ok` == the requested budget.

No production code changes — infra/docs only.