### PR TITLE
Update quiche-h3 to 0.0.3; treat quiche as a full benchmark transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "quiche-h3"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0a73289e282a0066258d81d90dd4d01d3bce47a1c39ac207543950ce2bb522"
+checksum = "f28c06c8f0aa552e6ea22cc1dbd37ae63a17a104c837d5e08aabf44aae62b1f8"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ hdrhistogram = { version = "7", default-features = false }
 serde_json = "1"
 
 # quiche-h3 bridge crate (implements the h3::quic traits over tokio-quiche)
-quiche-h3 = "0.0.2"
+quiche-h3 = "0.0.3"
 
 # crates in this workspace
 tonic-h3 = { path = "tonic-h3" }

--- a/docs/bench/README.md
+++ b/docs/bench/README.md
@@ -75,8 +75,21 @@ progression.
 
 ## Published results
 
-Curated result sets (raw artifacts stay git-ignored; only these tables are committed):
+Curated result sets (raw artifacts stay git-ignored; only these tables are committed).
 
-- [same-zone · `Standard_D2s_v5` · 2026-07-23](results/results-same-zone-d2s_v5-20260723.md)
-- [cross-zone · `Standard_D2s_v5` · 2026-07-23](results/results-cross-zone-d2s_v5-20260723.md)
-- [cross-region · `Standard_D2s_v5` · 2026-07-23](results/results-cross-region-d2s_v5-20260723.md)
+### Current — 5 transports (incl. quiche)
+
+`Standard_D2s_v5`, Ubuntu 26.04, `quiche-h3` 0.0.3:
+
+- [same-zone · 2026-07-25](results/results-same-zone-d2s_v5-20260725.md)
+- [cross-zone · 2026-07-25](results/results-cross-zone-d2s_v5-20260725.md)
+- [cross-region · 2026-07-25](results/results-cross-region-d2s_v5-20260725.md)
+
+### Archived
+
+Earlier runs, before quiche was fixed and added to the matrix (4 transports:
+`tcp-tls`, `quinn`, `msquic`, `s2n-quic`):
+
+- [same-zone · `Standard_D2s_v5` · 2026-07-23](results/archive/results-same-zone-d2s_v5-20260723.md)
+- [cross-zone · `Standard_D2s_v5` · 2026-07-23](results/archive/results-cross-zone-d2s_v5-20260723.md)
+- [cross-region · `Standard_D2s_v5` · 2026-07-23](results/archive/results-cross-region-d2s_v5-20260723.md)

--- a/docs/bench/results-template.md
+++ b/docs/bench/results-template.md
@@ -23,9 +23,6 @@ tables here — never the raw run artifacts (they are git-ignored).
 - **Always check `failed` and `ok`.** A high throughput number with non-zero
   `failed` (or `ok` far below the requested `count`) is not a valid data point —
   investigate before recording it.
-- **quiche is single-stream only** (`concurrency` forced to 1). Do **not** place
-  its throughput next to a concurrent `quinn`/`tcp-tls` number as if comparable;
-  compare it only against other `concurrency 1` runs, and annotate it.
 
 ---
 
@@ -51,12 +48,9 @@ you care about. State the fixed axes in the caption.
 | `s2n-quic` | same-zone    |                    |          |          |          |        |
 | `s2n-quic` | cross-zone   |                    |          |          |          |        |
 | `s2n-quic` | cross-region |                    |          |          |          |        |
-| `quiche`¹  | same-zone    |                    |          |          |          |        |
-| `quiche`¹  | cross-zone   |                    |          |          |          |        |
-| `quiche`¹  | cross-region |                    |          |          |          |        |
-
-¹ `quiche` is single-stream (`concurrency 1`); not directly comparable to the
-concurrent rows above.
+| `quiche`   | same-zone    |                    |          |          |          |        |
+| `quiche`   | cross-zone   |                    |          |          |          |        |
+| `quiche`   | cross-region |                    |          |          |          |        |
 
 ---
 
@@ -104,9 +98,8 @@ For each published sweep, add a short write-up alongside the tables:
   baseline on throughput and on tail latency.
 - **Where QUIC wins / loses:** call out the topology (RTT) and payload regimes
   where HTTP/3 helps vs where the TCP baseline is still ahead.
-- **Caveats:** experimental-backend quirks, the `quiche` single-stream
-  restriction, any non-zero `failed` counts, and NIC/CPU saturation if the SKU
-  looked like the bottleneck.
+- **Caveats:** experimental-backend quirks, any non-zero `failed` counts, and
+  NIC/CPU saturation if the SKU looked like the bottleneck.
 
 ## Reproducing a published number
 

--- a/docs/bench/results/archive/results-cross-region-d2s_v5-20260723.md
+++ b/docs/bench/results/archive/results-cross-region-d2s_v5-20260723.md
@@ -1,7 +1,7 @@
 # Results — cross-region, `Standard_D2s_v5` (2026-07-23)
 
 Curated results from the apples-to-apples comparison matrix
-([`scenarios.yml`](../../../tests/infra/ansible/scenarios.yml)): every comparable
+([`scenarios.yml`](../../../../tests/infra/ansible/scenarios.yml)): every comparable
 transport runs the same workload points. Raw run artifacts live in the
 git-ignored `tests/infra/ansible/results/` and are **not** committed; only these
 curated tables are.

--- a/docs/bench/results/archive/results-cross-zone-d2s_v5-20260723.md
+++ b/docs/bench/results/archive/results-cross-zone-d2s_v5-20260723.md
@@ -1,7 +1,7 @@
 # Results — cross-zone, `Standard_D2s_v5` (2026-07-23)
 
 Curated results from the apples-to-apples comparison matrix
-([`scenarios.yml`](../../../tests/infra/ansible/scenarios.yml)): every comparable
+([`scenarios.yml`](../../../../tests/infra/ansible/scenarios.yml)): every comparable
 transport runs the exact same workload points. Raw run artifacts live in the
 git-ignored `tests/infra/ansible/results/` and are **not** committed; only these
 curated tables are.

--- a/docs/bench/results/archive/results-same-zone-d2s_v5-20260723.md
+++ b/docs/bench/results/archive/results-same-zone-d2s_v5-20260723.md
@@ -1,7 +1,7 @@
 # Results — same-zone, `Standard_D2s_v5` (2026-07-23)
 
 Curated results from the apples-to-apples comparison matrix
-([`scenarios.yml`](../../../tests/infra/ansible/scenarios.yml)): every comparable
+([`scenarios.yml`](../../../../tests/infra/ansible/scenarios.yml)): every comparable
 transport runs the exact same workload points. Raw run artifacts live in the
 git-ignored `tests/infra/ansible/results/` and are **not** committed; only these
 curated tables are.
@@ -137,7 +137,7 @@ bottleneck at large messages on this 2-vCPU SKU.
 ## Reproducing
 
 Deploy the same topology and re-run the recorded matrix (see the
-[run procedure](../run-procedure.md)):
+[run procedure](../../run-procedure.md)):
 
 ```bash
 tests/infra/scripts/deploy.sh same-zone            # Ubuntu 26.04, D2s_v5, eastus2

--- a/docs/bench/results/results-cross-region-d2s_v5-20260725.md
+++ b/docs/bench/results/results-cross-region-d2s_v5-20260725.md
@@ -1,0 +1,139 @@
+# Results — cross-region, `Standard_D2s_v5` (2026-07-25)
+
+Curated results from the apples-to-apples comparison matrix
+([`scenarios.yml`](../../../tests/infra/ansible/scenarios.yml)): every transport
+runs the same workload points, now including **quiche** (`quiche-h3` 0.0.3 fixed
+the high-concurrency stall). Raw artifacts stay git-ignored; only these curated
+tables are committed. Earlier 4-transport runs are under [`archive/`](archive/).
+
+Companion runs: [same-zone](results-same-zone-d2s_v5-20260725.md) ·
+[cross-zone](results-cross-zone-d2s_v5-20260725.md).
+
+## Setup / provenance
+
+| Field | Value |
+|-------|-------|
+| Topology | `cross-region` (client eastus2 ↔ server westus2, peered private VNets) |
+| Measured RTT | **~67 ms** (`ping` min/avg/max 66.3 / 66.9 / 68.8 ms, 0 % loss) |
+| VM SKU | `Standard_D2s_v5` (2 vCPU / 8 GiB, Accelerated Networking) |
+| OS image | Ubuntu 26.04 LTS (`ubuntu-26_04-lts:server`, glibc 2.43) |
+| Client → Server | `tonich3-client` (eastus2, 10.20.1.4) → `tonich3-server` (westus2, 10.30.1.4) |
+| `libmsquic` | 2.5.8 |
+| `quiche-h3` | 0.0.3 |
+| Repo commit | `9fad5f3` |
+| Run id / UTC | `cd32e078a0c4c349` / `20260725T062815Z` |
+| Result | 25 / 25 scenarios, **0 failures** |
+
+**Method.** Five transports × five identical workload points. Throughput points
+use a fixed 15 s `duration` with a 3 s warmup (discarded). The latency point uses
+a fixed count — **reduced to 2 000** (vs 20 000 in-region) because at ~67 ms RTT a
+c=1 serialized run of 20 000 would take ~22 min per transport. gRPC echo over the
+private cross-region link.
+
+> At ~67 ms RTT the round-trip dominates: a c=1 run is pinned at ~1 RTT/request
+> (~15 req/s) for every transport, so Point 1 measures the link, not the
+> transport. The signal is in the concurrent points.
+
+---
+
+## Point 1 — latency probe (64 B, concurrency 1, count 2 000)
+
+All transports sit at the ~66 ms RTT floor (validates the link).
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `tcp-tls`  | 15                 | 65.919   | 66.175   | 0      |
+| `quinn`    | 15                 | 66.047   | 66.303   | 0      |
+| `msquic`   | 15                 | 65.919   | 66.175   | 0      |
+| `s2n-quic` | 15                 | 65.983   | 66.239   | 0      |
+| `quiche`   | 15                 | 65.919   | 66.175   | 0      |
+
+## Point 2 — small-payload throughput (64 B, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `quinn`    | 485                | 65.983   | 66.495   | 0      |
+| `s2n-quic` | 485                | 65.983   | 66.623   | 0      |
+| `quiche`   | 484                | 66.111   | 67.327   | 0      |
+| `msquic`   | 480                | 66.687   | 67.135   | 0      |
+| `tcp-tls`  | 336                | 67.839   | 131.839  | 0      |
+
+**All four QUIC backends (including quiche) beat the TCP baseline** by ~45 %, each
+holding a clean ~66 ms p99 while `tcp-tls` p99 doubles to ~132 ms (HTTP/2 HoL
+blocking over the WAN link).
+
+## Point 3 — high-concurrency throughput (64 B, concurrency 128, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `msquic`   | 1 864              | 68.863   | 70.655   | 0      |
+| `tcp-tls`  | 1 787              | 66.431   | 126.143  | 0      |
+| `quiche`   | 756                | 190.335  | 197.503  | 0      |
+| `quinn`    | 732                | 133.119  | 397.567  | 0      |
+| `s2n-quic` | 544                | 199.295  | 397.823  | 0      |
+
+`msquic` and `tcp-tls` scale cleanly to ~1 800. The other three lag, but
+**`quiche` holds the tightest tail of them (197 ms p99 vs ~398 ms for `quinn`/
+`s2n-quic`)** — a notable inversion: the previously-excluded backend now behaves
+better under this stress point than the two it used to be grouped against.
+
+## Point 4 — medium-payload throughput (4 KiB, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `quinn`    | 484                | 65.727   | 68.671   | 0      |
+| `s2n-quic` | 484                | 65.791   | 68.159   | 0      |
+| `quiche`   | 483                | 66.111   | 67.391   | 0      |
+| `msquic`   | 473                | 67.775   | 68.415   | 0      |
+| `tcp-tls`  | 465                | 66.047   | 126.399  | 0      |
+
+All QUIC backends cluster at ~1 RTT/request with tight ~68 ms tails; `tcp-tls`
+matches on throughput but shows a ~126 ms p99.
+
+## Point 5 — large-payload throughput (64 KiB, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `quinn`    | 479                | 66.495   | 67.647   | 0      |
+| `s2n-quic` | 479                | 66.431   | 73.983   | 0      |
+| `quiche`   | 477                | 66.751   | 72.703   | 0      |
+| `tcp-tls`  | 224                | 135.807  | 202.495  | 0      |
+| `msquic`   | 161                | 198.143  | 202.239  | 0      |
+
+**Biggest QUIC win:** `quinn`, `s2n-quic`, and `quiche` all sustain ~478 req/s at
+~66 ms p50 (1 RTT), while `tcp-tls` (224) and `msquic` (161) are 2–3× slower at
+2–3 RTT. quiche is fully competitive with the other userspace QUIC stacks here.
+
+---
+
+## Narrative
+
+- **Headline:** At ~67 ms cross-region RTT, HTTP/3 (QUIC) beats the TCP/TLS
+  baseline at moderate concurrency and large payloads — and **quiche is now a
+  full participant**, competitive with `quinn`/`s2n-quic` at c=32 and holding the
+  tightest tail of the three at c=128.
+- **quiche cross-region:** ties the QUIC pack at 64 B/c=32 (484 rps), 4 KiB (483),
+  and 64 KiB (477); at 64 B/c=128 it delivers 756 rps with a 197 ms p99 vs
+  ~398 ms for `quinn`/`s2n-quic`. A very different picture from same/cross-zone,
+  where it was the slowest transport.
+- **`quinn`/`s2n-quic` scaling limit persists:** both still collapse at 64 B/
+  c=128 (732 / 544 rps, ~398 ms p99) where `msquic`/`tcp-tls` scale to ~1 800 —
+  the userspace-QUIC high-concurrency / high-BDP limit noted in the archived run.
+- **Caveats:** 2 vCPU; the c=1 point used count 2 000 (RTT floor only). `msquic`,
+  `s2n-quic`, `quiche` are experimental.
+
+## Reproducing
+
+```bash
+tests/infra/scripts/deploy.sh cross-region         # eastus2 (client) + westus2 (server)
+cd tests/infra/ansible
+python3 inventory.py --resource-group rg-tonich3-bench-cross-region
+# latency point reduced to count 2000 for the ~67ms RTT link (else ~22 min/transport):
+ansible-playbook run-bench.yml -e @scenarios.yml \
+  -e '{"scenarios":[ ...scenarios.yml, but the c=1 points use count: 2000 ]}' \
+  -e topology=cross-region -e vm_size=Standard_D2s_v5 -e region=eastus2-westus2 \
+  -e bench_port=50051 -e bench_libmsquic_version=2.5.8
+```
+
+Each cell traces back to a `result-*.json` + `*.meta.json` pair in the
+git-ignored results dir (run id `cd32e078a0c4c349`).

--- a/docs/bench/results/results-cross-zone-d2s_v5-20260725.md
+++ b/docs/bench/results/results-cross-zone-d2s_v5-20260725.md
@@ -1,0 +1,113 @@
+# Results — cross-zone, `Standard_D2s_v5` (2026-07-25)
+
+Curated results from the apples-to-apples comparison matrix
+([`scenarios.yml`](../../../tests/infra/ansible/scenarios.yml)): every transport
+runs the exact same workload points, now including **quiche** (`quiche-h3` 0.0.3
+fixed the high-concurrency stall). Raw run artifacts stay git-ignored; only these
+curated tables are committed. Earlier 4-transport runs are under [`archive/`](archive/).
+
+Companion runs: [same-zone](results-same-zone-d2s_v5-20260725.md) ·
+cross-region (same date).
+
+## Setup / provenance
+
+| Field | Value |
+|-------|-------|
+| Topology | `cross-zone` (client zone 1, server zone 2, same region, peered private VNet) |
+| VM SKU | `Standard_D2s_v5` (2 vCPU / 8 GiB, Accelerated Networking) |
+| OS image | Ubuntu 26.04 LTS (`ubuntu-26_04-lts:server`, glibc 2.43) |
+| Region | `eastus2` |
+| Client → Server | `tonich3-client` (10.20.1.4, zone 1) → `tonich3-server` (10.20.1.5, zone 2) |
+| `libmsquic` | 2.5.8 |
+| `quiche-h3` | 0.0.3 |
+| Repo commit | `9fad5f3` |
+| Run id / UTC | `578d8708acdb0cd5` / `20260725T061055Z` |
+| Result | 25 / 25 scenarios, **0 failures** |
+
+**Method.** Five transports × five identical workload points. Throughput points
+use a fixed 15 s `duration` with a 3 s warmup (discarded); the latency point uses
+a fixed count of 20 000. gRPC echo over the private inter-zone link. `tcp-tls`
+(HTTP/2 baseline), `quinn` (**production** QUIC), `msquic` / `s2n-quic` / `quiche`
+(experimental QUIC).
+
+---
+
+## Point 1 — latency probe (64 B, concurrency 1, count 20 000)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `tcp-tls`  | 3 326              | 0.297    | 0.362    | 0      |
+| `quinn`    | 2 769              | 0.358    | 0.416    | 0      |
+| `s2n-quic` | 2 342              | 0.425    | 0.481    | 0      |
+| `msquic`   | 1 909              | 0.524    | 0.633    | 0      |
+| `quiche`   | 1 813              | 0.552    | 0.625    | 0      |
+
+## Point 2 — small-payload throughput (64 B, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `s2n-quic` | 42 613             | 0.728    | 1.395    | 0      |
+| `tcp-tls`  | 41 481             | 0.761    | 1.082    | 0      |
+| `quinn`    | 38 819             | 0.815    | 1.241    | 0      |
+| `msquic`   | 25 547             | 1.249    | 1.596    | 0      |
+| `quiche`   | 20 522             | 1.510    | 2.607    | 0      |
+
+## Point 3 — high-concurrency throughput (64 B, concurrency 128, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `tcp-tls`  | 59 177             | 2.083    | 3.443    | 0      |
+| `s2n-quic` | 49 955             | 2.437    | 5.571    | 0      |
+| `quinn`    | 46 886             | 2.497    | 6.211    | 0      |
+| `msquic`   | 35 312             | 3.657    | 4.787    | 0      |
+| `quiche`   | 19 275             | 6.731    | 9.799    | 0      |
+
+## Point 4 — medium-payload throughput (4 KiB, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `s2n-quic` | 25 747             | 1.232    | 1.719    | 0      |
+| `tcp-tls`  | 24 009             | 1.309    | 2.033    | 0      |
+| `quinn`    | 22 658             | 1.417    | 2.137    | 0      |
+| `msquic`   | 18 552             | 1.730    | 2.163    | 0      |
+| `quiche`   | 12 699             | 2.469    | 4.007    | 0      |
+
+## Point 5 — large-payload throughput (64 KiB, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `tcp-tls`  | 6 348              | 4.915    | 8.199    | 0      |
+| `msquic`   | 3 895              | 8.083    | 11.919   | 0      |
+| `s2n-quic` | 3 122              | 11.399   | 14.391   | 0      |
+| `quinn`    | 3 091              | 11.103   | 15.767   | 0      |
+| `quiche`   | 1 971              | 16.607   | 26.911   | 0      |
+
+---
+
+## Narrative
+
+- **Headline:** Cross-zone (sub-ms inter-zone RTT) mirrors same-zone: the TCP/TLS
+  baseline leads or ties, `s2n-quic` is the best QUIC backend, `quinn` close
+  behind on small payloads, `msquic`/`quiche` trail. `quiche` completes every
+  point with **0 failures**.
+- **quiche behavior:** functional at all concurrencies but the slowest transport;
+  like same-zone it does not gain throughput from c=32→c=128 (~20k both).
+- **Baseline vs QUIC:** the small inter-zone RTT is still not enough for QUIC's
+  loss/HoL advantages to overturn the baseline — that shift appears at
+  cross-region RTT (see the cross-region run).
+- **Caveats:** 2 vCPU is CPU-bound for userspace QUIC at 64 KiB. `msquic`,
+  `s2n-quic`, and `quiche` are experimental.
+
+## Reproducing
+
+```bash
+tests/infra/scripts/deploy.sh cross-zone           # Ubuntu 26.04, D2s_v5, eastus2 z1/z2
+cd tests/infra/ansible
+python3 inventory.py --resource-group rg-tonich3-bench-cross-zone
+ansible-playbook run-bench.yml -e @scenarios.yml \
+  -e topology=cross-zone -e vm_size=Standard_D2s_v5 -e region=eastus2 \
+  -e bench_port=50051 -e bench_libmsquic_version=2.5.8
+```
+
+Each cell traces back to a `result-*.json` + `*.meta.json` pair in the
+git-ignored results dir (run id `578d8708acdb0cd5`).

--- a/docs/bench/results/results-same-zone-d2s_v5-20260725.md
+++ b/docs/bench/results/results-same-zone-d2s_v5-20260725.md
@@ -1,0 +1,120 @@
+# Results — same-zone, `Standard_D2s_v5` (2026-07-25)
+
+Curated results from the apples-to-apples comparison matrix
+([`scenarios.yml`](../../../tests/infra/ansible/scenarios.yml)): every transport
+runs the exact same workload points. This is the first run to include **quiche**
+as a full transport (the high-concurrency stall was fixed in `quiche-h3` 0.0.3).
+Raw run artifacts live in the git-ignored `tests/infra/ansible/results/` and are
+**not** committed; only these curated tables are.
+
+Earlier 4-transport runs are archived under [`archive/`](archive/).
+
+## Setup / provenance
+
+| Field | Value |
+|-------|-------|
+| Topology | `same-zone` (both VMs in eastus2, zone 1, peered private VNet) |
+| VM SKU | `Standard_D2s_v5` (2 vCPU / 8 GiB, Accelerated Networking) |
+| OS image | Ubuntu 26.04 LTS (`ubuntu-26_04-lts:server`, glibc 2.43) |
+| Region | `eastus2` |
+| Client → Server | `tonich3-client` (10.20.1.4) → `tonich3-server` (10.20.1.5) |
+| `libmsquic` | 2.5.8 |
+| `quiche-h3` | 0.0.3 |
+| Repo commit | `9fad5f3` |
+| Run id / UTC | `33dc12016ac0b0aa` / `20260725T055440Z` |
+| Result | 25 / 25 scenarios, **0 failures** |
+
+**Method.** Each of the five transports runs the identical five workload points.
+Throughput points use a fixed 15 s `duration` at steady state with a 3 s warmup
+(discarded), uniform across transports; the latency point uses a fixed count of
+20 000 requests (no warmup). gRPC echo over the private network. Transports:
+`tcp-tls` (tonic + tonic-tls, HTTP/2 baseline), `quinn` (**production** QUIC),
+`msquic` / `s2n-quic` / `quiche` (experimental QUIC).
+
+---
+
+## Point 1 — latency probe (64 B, concurrency 1, count 20 000)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|----------|--------|
+| `tcp-tls`  | 5 527              | 0.178    | —        | 0.228    | 0      |
+| `quinn`    | 5 219              | 0.187    | —        | 0.256    | 0      |
+| `s2n-quic` | 4 827              | 0.204    | —        | 0.254    | 0      |
+| `quiche`   | 3 292              | 0.296    | —        | 0.445    | 0      |
+| `msquic`   | 3 055              | 0.317    | —        | 0.481    | 0      |
+
+`tcp-tls`/`quinn` lead; `quiche` and `msquic` share the slowest single-request path.
+
+## Point 2 — small-payload throughput (64 B, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `tcp-tls`  | 47 876             | 0.651    | 1.089    | 0      |
+| `s2n-quic` | 45 672             | 0.681    | 1.257    | 0      |
+| `quinn`    | 42 211             | 0.740    | 1.423    | 0      |
+| `msquic`   | 27 563             | 1.149    | 1.646    | 0      |
+| `quiche`   | 20 525             | 1.492    | 2.773    | 0      |
+
+## Point 3 — high-concurrency throughput (64 B, concurrency 128, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `tcp-tls`  | 65 109             | 1.881    | 3.257    | 0      |
+| `s2n-quic` | 50 733             | 2.413    | 5.171    | 0      |
+| `quinn`    | 49 827             | 2.373    | 5.671    | 0      |
+| `msquic`   | 35 702             | 3.619    | 4.839    | 0      |
+| `quiche`   | 20 448             | 6.175    | 9.639    | 0      |
+
+`quiche` does **not** scale with concurrency here (~20.5k at both c=32 and c=128)
+— it is the slowest QUIC backend but completes cleanly with no failures.
+
+## Point 4 — medium-payload throughput (4 KiB, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `s2n-quic` | 27 158             | 1.152    | 1.821    | 0      |
+| `tcp-tls`  | 26 781             | 1.174    | 1.849    | 0      |
+| `quinn`    | 25 557             | 1.249    | 1.940    | 0      |
+| `msquic`   | 18 914             | 1.696    | 2.109    | 0      |
+| `quiche`   | 14 104             | 2.209    | 3.707    | 0      |
+
+## Point 5 — large-payload throughput (64 KiB, concurrency 32, 15 s)
+
+| Transport  | Throughput (req/s) | p50 (ms) | p99 (ms) | failed |
+|------------|--------------------|----------|----------|--------|
+| `tcp-tls`  | 6 785              | 4.595    | 7.875    | 0      |
+| `msquic`   | 3 683              | 8.623    | 12.551   | 0      |
+| `s2n-quic` | 3 236              | 10.983   | 13.687   | 0      |
+| `quinn`    | 2 844              | 12.095   | 16.991   | 0      |
+| `quiche`   | 2 225              | 14.319   | 22.287   | 0      |
+
+---
+
+## Narrative
+
+- **Headline:** On a 2-vCPU same-zone pair the TCP/TLS (HTTP/2) baseline leads or
+  ties everywhere; `s2n-quic` is the strongest QUIC backend, production `quinn`
+  is close behind on small payloads, and `msquic`/`quiche` trail.
+- **quiche now works at concurrency.** Every quiche scenario completed with 0
+  failures (previously it was excluded because it stalled above c=1). It is the
+  slowest QUIC backend here and does not gain throughput from c=32→c=128, but it
+  is functionally correct.
+- **Baseline vs QUIC:** as before, sub-ms same-zone RTT favors the TCP baseline —
+  QUIC's loss/HoL advantages don't manifest on a lossless in-zone link. See the
+  cross-zone and cross-region runs where the ordering shifts.
+- **Caveats:** 2 vCPU is CPU-bound for userspace QUIC at 64 KiB. `msquic`,
+  `s2n-quic`, and `quiche` are experimental backends.
+
+## Reproducing
+
+```bash
+tests/infra/scripts/deploy.sh same-zone            # Ubuntu 26.04, D2s_v5, eastus2
+cd tests/infra/ansible
+python3 inventory.py --resource-group rg-tonich3-bench-same-zone
+ansible-playbook run-bench.yml -e @scenarios.yml \
+  -e topology=same-zone -e vm_size=Standard_D2s_v5 -e region=eastus2 \
+  -e bench_port=50051 -e bench_libmsquic_version=2.5.8
+```
+
+Each cell traces back to a `result-*.json` + `*.meta.json` pair in the
+git-ignored results dir (run id `33dc12016ac0b0aa`).

--- a/docs/bench/run-procedure.md
+++ b/docs/bench/run-procedure.md
@@ -170,9 +170,8 @@ with a `block/rescue/always` lifecycle:
    (graceful QUIC teardown frees the port), verifying the process exited before
    the next scenario.
 
-`quiche` is automatically pinned to `--concurrency 1`. The `topology`,
-`vm_size`, and `region` you pass are recorded in every filename and metadata
-sidecar (defaulting to `unknown` if omitted), so cross-SKU runs stay
+The `topology`, `vm_size`, and `region` you pass are recorded in every filename
+and metadata sidecar (defaulting to `unknown` if omitted), so cross-SKU runs stay
 distinguishable. See the [scenario matrix](scenario-matrix.md) for the axes.
 
 ### Where results land

--- a/docs/bench/scenario-matrix.md
+++ b/docs/bench/scenario-matrix.md
@@ -27,12 +27,12 @@ come from the deployed infrastructure, not from the scenario list).
 | `quinn`    | HTTP/3 over QUIC      | production   | The primary HTTP/3 implementation. |
 | `msquic`   | HTTP/3 over QUIC      | experimental | Microsoft's C QUIC library (native `libmsquic`). |
 | `s2n-quic` | HTTP/3 over QUIC      | experimental | AWS's QUIC implementation. |
-| `quiche`   | HTTP/3 over QUIC      | experimental | Cloudflare's QUIC — **unstable at high concurrency**. |
+| `quiche`   | HTTP/3 over QUIC      | experimental | Cloudflare's QUIC. |
 
-> **quiche caveat.** `quiche` stalls above a single in-flight request, so the
-> orchestration **forces `--concurrency 1`** for it regardless of what the
-> scenario asks. Treat `quiche` numbers as single-stream only and never compare
-> its throughput head-to-head with a concurrent `quinn`/`tcp-tls` run.
+> **quiche note.** `quiche` previously stalled above a single in-flight request,
+> and the orchestration forced `--concurrency 1` for it. That stall was fixed in
+> `quiche-h3` 0.0.3, so `quiche` now runs at any concurrency and is a full member
+> of the comparison matrix like every other transport.
 
 ### Payload sizes
 
@@ -46,7 +46,7 @@ come from the deployed infrastructure, not from the scenario list).
 
 | Concurrency | What it isolates |
 |-------------|------------------|
-| `1`   | Pure round-trip latency (p50/p90/p99 with no queuing). Also the only valid setting for `quiche`. |
+| `1`   | Pure round-trip latency (p50/p90/p99 with no queuing). |
 | `16`  | Moderate parallelism — typical service load. |
 | `32`+ | Saturation — where multiplexing, congestion control, and CPU start to bound throughput. |
 
@@ -97,7 +97,7 @@ experimental backend:
 | 3 | `quinn`    | 4 KiB   | 32          | count 20 000 |
 | 4 | `msquic`   | 64 B    | 16          | count 10 000 |
 | 5 | `s2n-quic` | 64 B    | 16          | count 10 000 |
-| 6 | `quiche`   | 64 B    | 1 (forced)  | count 5 000  |
+| 6 | `quiche`   | 64 B    | 16          | count 10 000 |
 
 ## Extended matrix (`scenarios.yml`)
 

--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -36,9 +36,9 @@ The same echo RPC runs over five transports, selected with `--transport`:
 > `s2n-quic`, and `quiche` are **experimental** and provided for evaluation
 > only, matching the support matrix in the [root README](../../README.md).
 >
-> **Known experimental-backend caveat:** the `quiche` client can stall under
-> high concurrency. Benchmark it with `--concurrency 1` for stable results
-> (see [Interpreting results](#interpreting-results)).
+> **Note:** the `quiche` client previously stalled under high concurrency; this
+> was fixed in `quiche-h3` 0.0.3, so `quiche` now runs at any concurrency like
+> the other transports.
 
 The `tcp-tls` transport negotiates **HTTP/2** (ALPN `h2`); the four QUIC
 transports negotiate **HTTP/3** (ALPN `h3`). This lets you compare gRPC over
@@ -124,13 +124,13 @@ cargo run -p tonic-h3-bench --bin bench-client -- --transport s2n-quic --addr 12
     --count 20000 --concurrency 16
 ```
 
-**HTTP/3 over quiche (experimental)** — prefer `--concurrency 1` (see the
-[caveat](#transports-compared)):
+**HTTP/3 over quiche (experimental)** — runs at any concurrency (the old
+high-concurrency stall was fixed in `quiche-h3` 0.0.3):
 
 ```bash
 cargo run -p tonic-h3-bench --bin bench-server -- --transport quiche --addr 127.0.0.1:5000
 cargo run -p tonic-h3-bench --bin bench-client -- --transport quiche --addr 127.0.0.1:5000 \
-    --count 20000 --concurrency 1
+    --count 20000 --concurrency 16
 ```
 
 The server runs until it receives **Ctrl-C** (SIGINT) or **SIGTERM**, then runs
@@ -253,9 +253,8 @@ Each client run has three stages:
   measures round-trip latency; many workers measure pipeline throughput.
 - **Watch the `failed` count and `elapsed`.** A non-zero `failed` count or an
   `elapsed` far larger than the latency percentiles imply indicates instability
-  rather than throughput — e.g. the `quiche` backend stalls under high
-  concurrency, producing a few failures and a long tail. Re-run experimental
-  backends at `--concurrency 1` to confirm.
+  rather than throughput. If a run shows this, re-run it and check for a stalled
+  or saturated backend.
 - **Percentiles over averages.** p99 exposes tail latency (queueing, retransmit,
   GC pauses) that a mean would hide; it is usually the most decision-relevant
   number for RPC systems.

--- a/tests/infra/ansible/run-bench.yml
+++ b/tests/infra/ansible/run-bench.yml
@@ -20,9 +20,6 @@
 # private IP / VM name from inventory hostvars. This avoids run_once coordination
 # subtleties while still orchestrating both nodes.
 #
-# quiche is forced to --concurrency 1 (it stalls under higher concurrency); the
-# effective concurrency is what lands in the result filename and metadata.
-#
 # Usage (run from tests/infra/ansible/ so ansible.cfg is active):
 #   python3 inventory.py --topology same-zone
 #   ansible-playbook run-bench.yml -e topology=same-zone -e vm_size=Standard_D2s_v5 -e region=eastus2
@@ -73,7 +70,7 @@
       - { transport: quinn,    payload_size: 4096, concurrency: 32, count: 20000 }
       - { transport: msquic,   payload_size: 64,   concurrency: 16, count: 10000 }
       - { transport: s2n-quic, payload_size: 64,   concurrency: 16, count: 10000 }
-      - { transport: quiche,   payload_size: 64,   concurrency: 1,  count: 5000 }
+      - { transport: quiche,   payload_size: 64,   concurrency: 16, count: 10000 }
   tasks:
     - name: Validate the scenario matrix before starting anything
       # Fail fast and precisely on malformed extra-vars rather than silently

--- a/tests/infra/ansible/scenarios.example.yml
+++ b/tests/infra/ansible/scenarios.example.yml
@@ -11,7 +11,7 @@
 # Each scenario is a dict:
 #   transport     : tcp-tls | quinn | msquic | s2n-quic | quiche
 #   payload_size  : echo payload in bytes
-#   concurrency   : in-flight workers (quiche is auto-forced to 1)
+#   concurrency   : in-flight workers
 #   count | duration : request budget (fixed count) OR wall-clock seconds (exactly one)
 #   port          : (optional) data-plane port override; defaults to bench_port
 #
@@ -31,8 +31,8 @@ scenarios:
   # --- Experimental backends (evaluation only) ---
   - { transport: msquic,   payload_size: 64,   concurrency: 16,  count: 20000 }
   - { transport: s2n-quic, payload_size: 64,   concurrency: 16,  count: 20000 }
-  # quiche: concurrency is forced to 1 by the playbook regardless of this value.
-  - { transport: quiche,   payload_size: 64,   concurrency: 1,   count: 10000 }
+  # quiche now runs at any concurrency (the old c=1 stall was fixed in quiche-h3 0.0.3).
+  - { transport: quiche,   payload_size: 64,   concurrency: 16,  count: 10000 }
 
   # --- Duration-based steady-state sample (demonstrates the duration budget) ---
   - { transport: quinn,   payload_size: 64,    concurrency: 32,  duration: 30 }

--- a/tests/infra/ansible/scenarios.yml
+++ b/tests/infra/ansible/scenarios.yml
@@ -5,16 +5,17 @@
 # results are directly comparable transport-by-transport. Five workload points
 # (a latency probe, two concurrency levels at the small RPC payload, plus a
 # medium and a large payload throughput point) are applied identically to each
-# of the four comparable transports:
+# of the five transports:
 #
 #   tcp-tls  - tonic + tonic-tls over TCP/TLS (HTTP/2). The non-QUIC baseline.
 #   quinn    - tonic-h3 over QUIC (the production-supported backend).
 #   msquic   - tonic-h3 over QUIC (experimental backend).
 #   s2n-quic - tonic-h3 over QUIC (experimental backend).
+#   quiche   - tonic-h3 over QUIC (experimental backend).
 #
-# quiche is intentionally EXCLUDED: it stalls above concurrency 1, so it cannot
-# run the shared concurrency>=32 points and would not be an apples-to-apples
-# comparison. Evaluate it separately with a concurrency-1 matrix if needed.
+# NOTE: quiche previously stalled above concurrency 1 and was excluded from the
+# concurrent points; that was fixed in quiche-h3 0.0.3, so it now runs the full
+# matrix like every other transport.
 #
 # Budget choice: throughput points use a fixed wall-clock `duration` (steady
 # state, identical measurement window for every transport); the latency point
@@ -33,7 +34,7 @@
 #     -e bench_port=50051 -e bench_libmsquic_version=2.5.8
 #
 # Each scenario is a dict:
-#   transport     : tcp-tls | quinn | msquic | s2n-quic
+#   transport     : tcp-tls | quinn | msquic | s2n-quic | quiche
 #   payload_size  : echo payload in bytes
 #   concurrency   : in-flight workers
 #   count | duration : request budget (fixed count) OR wall-clock seconds (one)
@@ -49,6 +50,7 @@ scenarios:
   - { transport: quinn,    payload_size: 64,    concurrency: 1,   count: 20000 }
   - { transport: msquic,   payload_size: 64,    concurrency: 1,   count: 20000 }
   - { transport: s2n-quic, payload_size: 64,    concurrency: 1,   count: 20000 }
+  - { transport: quiche,   payload_size: 64,    concurrency: 1,   count: 20000 }
 
   # === Point 2: throughput - small payload, moderate concurrency (c=32) ======
   # The primary small-RPC throughput comparison point.
@@ -56,6 +58,7 @@ scenarios:
   - { transport: quinn,    payload_size: 64,    concurrency: 32,  duration: 15 }
   - { transport: msquic,   payload_size: 64,    concurrency: 32,  duration: 15 }
   - { transport: s2n-quic, payload_size: 64,    concurrency: 32,  duration: 15 }
+  - { transport: quiche,   payload_size: 64,    concurrency: 32,  duration: 15 }
 
   # === Point 3: throughput - small payload, high concurrency (c=128) =========
   # Stresses stream multiplexing / scheduling under heavier in-flight load.
@@ -63,6 +66,7 @@ scenarios:
   - { transport: quinn,    payload_size: 64,    concurrency: 128, duration: 15 }
   - { transport: msquic,   payload_size: 64,    concurrency: 128, duration: 15 }
   - { transport: s2n-quic, payload_size: 64,    concurrency: 128, duration: 15 }
+  - { transport: quiche,   payload_size: 64,    concurrency: 128, duration: 15 }
 
   # === Point 4: throughput - medium payload (4 KiB), moderate concurrency ====
   # Representative message size; balances framing overhead vs. bandwidth.
@@ -70,6 +74,7 @@ scenarios:
   - { transport: quinn,    payload_size: 4096,  concurrency: 32,  duration: 15 }
   - { transport: msquic,   payload_size: 4096,  concurrency: 32,  duration: 15 }
   - { transport: s2n-quic, payload_size: 4096,  concurrency: 32,  duration: 15 }
+  - { transport: quiche,   payload_size: 4096,  concurrency: 32,  duration: 15 }
 
   # === Point 5: throughput - large payload (64 KiB), moderate concurrency ====
   # Bandwidth-bound regime; surfaces per-transport copy/flow-control overhead.
@@ -77,3 +82,4 @@ scenarios:
   - { transport: quinn,    payload_size: 65536, concurrency: 32,  duration: 15 }
   - { transport: msquic,   payload_size: 65536, concurrency: 32,  duration: 15 }
   - { transport: s2n-quic, payload_size: 65536, concurrency: 32,  duration: 15 }
+  - { transport: quiche,   payload_size: 65536, concurrency: 32,  duration: 15 }

--- a/tests/infra/ansible/tasks/run-scenario.yml
+++ b/tests/infra/ansible/tasks/run-scenario.yml
@@ -10,8 +10,6 @@
 # invocation never collide), the play vars, and run_ts/run_id/git_commit.
 - name: "Scenario #{{ scenario_index }} {{ scenario.transport }} p{{ scenario.payload_size }} c{{ scenario.concurrency }}"
   vars:
-    # quiche stalls above concurrency 1 (see tests/bench/README.md); force it.
-    eff_conc: "{{ 1 if scenario.transport == 'quiche' else scenario.concurrency }}"
     port: "{{ scenario.port | default(bench_port) }}"
     # Exactly one of count/duration is present per scenario (validated upfront).
     budget_args: "{{ ('--count ' ~ scenario.count) if scenario.count is defined else ('--duration ' ~ scenario.duration) }}"
@@ -26,7 +24,7 @@
     server_ip: "{{ hostvars['server'].private_ip }}"
     # A zero-padded scenario index guarantees uniqueness within one invocation;
     # run_ts + run_id keep runs unique across invocations/machines/SKUs.
-    result_base: "result-{{ topology }}-{{ vm_size }}-{{ scenario.transport }}-p{{ scenario.payload_size }}-c{{ eff_conc }}-{{ budget_label }}-{{ run_ts }}-{{ run_id }}-s{{ '%03d' % (scenario_index | int) }}"
+    result_base: "result-{{ topology }}-{{ vm_size }}-{{ scenario.transport }}-p{{ scenario.payload_size }}-c{{ scenario.concurrency }}-{{ budget_label }}-{{ run_ts }}-{{ run_id }}-s{{ '%03d' % (scenario_index | int) }}"
     remote_result: "{{ bench_results_dir_remote }}/{{ result_base }}.json"
     remote_meta: "{{ bench_results_dir_remote }}/{{ result_base }}.meta.json"
     remote_log: "{{ bench_results_dir_remote }}/{{ result_base }}.server.log"
@@ -48,8 +46,7 @@
           region: "{{ region }}"
           transport: "{{ scenario.transport }}"
           payload_size: "{{ scenario.payload_size }}"
-          concurrency: "{{ eff_conc | int }}"
-          requested_concurrency: "{{ scenario.concurrency }}"
+          concurrency: "{{ scenario.concurrency | int }}"
           budget: "{{ ('count=' ~ scenario.count) if scenario.count is defined else ('duration=' ~ scenario.duration ~ 's') }}"
           warmup: "{{ warmup | int }}"
           port: "{{ port | int }}"
@@ -90,7 +87,7 @@
           --transport {{ scenario.transport }}
           --addr {{ server_ip }}:{{ port }}
           --payload-size {{ scenario.payload_size }}
-          --concurrency {{ eff_conc }}
+          --concurrency {{ scenario.concurrency }}
           {{ budget_args }}
           {{ warmup_args }}
           --format json
@@ -110,7 +107,7 @@
       ansible.builtin.debug:
         msg: >-
           Scenario #{{ scenario_index }} {{ scenario.transport }}
-          p{{ scenario.payload_size }} c{{ eff_conc }} FAILED; the result may be
+          p{{ scenario.payload_size }} c{{ scenario.concurrency }} FAILED; the result may be
           empty. See the fetched {{ result_base }}.client.log /
           {{ result_base }}.server.log for the cause.
 


### PR DESCRIPTION
## Summary

Bumps **`quiche-h3` 0.0.2 → 0.0.3**, which fixes the high-concurrency stall
tracked in #43, and unwinds all the workarounds that existed only because of
that bug. quiche now runs concurrent workloads like every other transport.

## The fix

Before (0.0.2), on loopback the trailing `concurrency − 1` in-flight requests
hung indefinitely — surfacing as `failed == concurrency − 1` with `elapsed`
pinned to `--request-timeout`. After (0.0.3), the same sweep completes with **0
failures** at every concurrency:

| Concurrency | 0.0.2 failed | 0.0.3 failed | 0.0.3 rps |
|-------------|--------------|--------------|-----------|
| 1   | 0  | 0 | 1 583 |
| 8   | 7  | 0 | 6 421 |
| 16  | 15 | 0 | 9 047 |
| 32  | 31 | 0 | 12 385 |
| 128 | 63 | 0 | 7 327 |

## Changes

- **`Cargo.toml` / `Cargo.lock`** — bump `quiche-h3` to 0.0.3 (no transitive
  bumps).
- **`tasks/run-scenario.yml`** — drop the `eff_conc` workaround that forced
  quiche to `--concurrency 1`; use `scenario.concurrency` directly and remove
  the now-redundant `requested_concurrency` metadata field.
- **`scenarios.yml`** — add quiche as a fifth transport across all five workload
  points (now 25 scenarios) so it joins the apples-to-apples matrix.
- **`run-bench.yml` / `scenarios.example.yml`** — run quiche at real concurrency;
  drop the "forced to c=1" notes.
- **Docs** (`tests/bench/README.md`, `docs/bench/{scenario-matrix,run-procedure,
  results-template}.md`) — replace the "quiche stalls / single-stream only /
  forced to concurrency 1" caveats with a note that the stall was fixed in
  quiche-h3 0.0.3.

## Validation

- quiche loopback sweep (c=1…128): **0 failures** (was `failed == c − 1`).
- Both quiche integration tests (`mix::h3_quiche_test`, `reconnect::h3_quiche_test`) pass.
- `cargo clippy --locked` clean on the affected crates.
- `ansible-playbook run-bench.yml --syntax-check` passes; a c=32 loopback
  harness dry-run runs quiche with **0 failures** and records `concurrency: 32`
  (no longer forced to 1).

Closes #43.